### PR TITLE
Change executable name from markdownlint-rs to mdlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,17 +111,17 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-dogfood-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build markdownlint-rs
+      - name: Build mdlint
         run: cargo build --release
 
       - name: Lint project documentation
         run: |
-          ./target/release/markdownlint-rs README.md CONTRIBUTING.md CLAUDE.md IMPROVEMENTS.md .github/WORKFLOWS.md
+          ./target/release/mdlint README.md CONTRIBUTING.md CLAUDE.md IMPROVEMENTS.md .github/WORKFLOWS.md
 
       - name: Lint all markdown (should only fail on test fixtures)
         run: |
           # This will exit 1 due to test fixtures, which is expected
-          ./target/release/markdownlint-rs || echo "✅ Expected violations in test fixtures"
+          ./target/release/mdlint || echo "✅ Expected violations in test fixtures"
 
   build:
     name: Build

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -104,11 +104,11 @@ jobs:
 
             ```bash
             # Linux/macOS
-            sha256sum -c markdownlint-rs-*.sha256
+            sha256sum -c mdlint-*.sha256
 
             # Windows (PowerShell)
-            $expected = (Get-Content markdownlint-rs-*.sha256).Split()[0]
-            $actual = (Get-FileHash markdownlint-rs-*.exe).Hash.ToLower()
+            $expected = (Get-Content mdlint-*.sha256).Split()[0]
+            $actual = (Get-FileHash mdlint.exe).Hash.ToLower()
             if ($expected -eq $actual) { "OK" } else { "FAILED" }
             ```
 
@@ -142,39 +142,39 @@ jobs:
           # Linux x86_64
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact_name: markdownlint-rs
-            asset_name: markdownlint-rs-linux-x86_64
+            artifact_name: mdlint
+            asset_name: mdlint-linux-x86_64
 
           # Linux x86_64 (musl - static binary)
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            artifact_name: markdownlint-rs
-            asset_name: markdownlint-rs-linux-x86_64-musl
+            artifact_name: mdlint
+            asset_name: mdlint-linux-x86_64-musl
 
           # Linux aarch64
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            artifact_name: markdownlint-rs
-            asset_name: markdownlint-rs-linux-aarch64
+            artifact_name: mdlint
+            asset_name: mdlint-linux-aarch64
             cross: true
 
           # macOS x86_64
           - os: macos-latest
             target: x86_64-apple-darwin
-            artifact_name: markdownlint-rs
-            asset_name: markdownlint-rs-macos-x86_64
+            artifact_name: mdlint
+            asset_name: mdlint-macos-x86_64
 
           # macOS aarch64 (Apple Silicon)
           - os: macos-latest
             target: aarch64-apple-darwin
-            artifact_name: markdownlint-rs
-            asset_name: markdownlint-rs-macos-aarch64
+            artifact_name: mdlint
+            asset_name: mdlint-macos-aarch64
 
           # Windows x86_64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            artifact_name: markdownlint-rs.exe
-            asset_name: markdownlint-rs-windows-x86_64.exe
+            artifact_name: mdlint.exe
+            asset_name: mdlint-windows-x86_64.exe
 
     steps:
       - name: Checkout repository

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/swanysimon/markdownlint-rs"
 keywords = ["markdown", "lint", "cli", "formatter"]
 categories = ["command-line-utilities", "development-tools"]
 
+[[bin]]
+name = "mdlint"
+path = "src/main.rs"
+
 [dependencies]
 # CLI parsing
 clap = { version = "4.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -33,43 +33,43 @@ Download the latest release for your platform from the [releases page](https://g
 
 **Linux (x86_64)**:
 ```bash
-curl -LO https://github.com/swanysimon/markdownlint-rs/releases/latest/download/markdownlint-rs-linux-x86_64.tar.gz
-tar xzf markdownlint-rs-linux-x86_64.tar.gz
-sudo mv markdownlint-rs /usr/local/bin/
+curl -LO https://github.com/swanysimon/markdownlint-rs/releases/latest/download/mdlint-linux-x86_64.tar.gz
+tar xzf mdlint-linux-x86_64.tar.gz
+sudo mv mdlint /usr/local/bin/
 ```
 
 **Linux (ARM64)**:
 ```bash
-curl -LO https://github.com/swanysimon/markdownlint-rs/releases/latest/download/markdownlint-rs-linux-aarch64.tar.gz
-tar xzf markdownlint-rs-linux-aarch64.tar.gz
-sudo mv markdownlint-rs /usr/local/bin/
+curl -LO https://github.com/swanysimon/markdownlint-rs/releases/latest/download/mdlint-linux-aarch64.tar.gz
+tar xzf mdlint-linux-aarch64.tar.gz
+sudo mv mdlint /usr/local/bin/
 ```
 
 **macOS (Intel)**:
 ```bash
-curl -LO https://github.com/swanysimon/markdownlint-rs/releases/latest/download/markdownlint-rs-macos-x86_64.tar.gz
-tar xzf markdownlint-rs-macos-x86_64.tar.gz
-sudo mv markdownlint-rs /usr/local/bin/
+curl -LO https://github.com/swanysimon/markdownlint-rs/releases/latest/download/mdlint-macos-x86_64.tar.gz
+tar xzf mdlint-macos-x86_64.tar.gz
+sudo mv mdlint /usr/local/bin/
 ```
 
 **macOS (Apple Silicon)**:
 ```bash
-curl -LO https://github.com/swanysimon/markdownlint-rs/releases/latest/download/markdownlint-rs-macos-aarch64.tar.gz
-tar xzf markdownlint-rs-macos-aarch64.tar.gz
-sudo mv markdownlint-rs /usr/local/bin/
+curl -LO https://github.com/swanysimon/markdownlint-rs/releases/latest/download/mdlint-macos-aarch64.tar.gz
+tar xzf mdlint-macos-aarch64.tar.gz
+sudo mv mdlint /usr/local/bin/
 ```
 
 **Windows**:
-Download `markdownlint-rs-windows-x86_64.exe.zip` from the releases page and extract it to a directory in your PATH.
+Download `mdlint-windows-x86_64.exe.zip` from the releases page and extract it to a directory in your PATH.
 
 **Verify checksum** (optional but recommended):
 ```bash
 # Linux/macOS
-sha256sum -c markdownlint-rs-*.sha256
+sha256sum -c mdlint-*.sha256
 
 # Windows (PowerShell)
-$expected = (Get-Content markdownlint-rs-*.sha256).Split()[0]
-$actual = (Get-FileHash markdownlint-rs.exe).Hash.ToLower()
+$expected = (Get-Content mdlint-*.sha256).Split()[0]
+$actual = (Get-FileHash mdlint.exe).Hash.ToLower()
 if ($expected -eq $actual) { "OK" } else { "FAILED" }
 ```
 
@@ -85,7 +85,7 @@ cargo install markdownlint-rs
 git clone https://github.com/swanysimon/markdownlint-rs.git
 cd markdownlint-rs
 cargo build --release
-sudo cp target/release/markdownlint-rs /usr/local/bin/
+sudo cp target/release/mdlint /usr/local/bin/
 ```
 
 ### Docker
@@ -128,23 +128,23 @@ The Docker image supports both `linux/amd64` and `linux/arm64` platforms.
 
 Lint all Markdown files in the current directory:
 ```bash
-markdownlint-rs
+mdlint
 ```
 
 Lint specific files or directories:
 ```bash
-markdownlint-rs README.md docs/
+mdlint README.md docs/
 ```
 
 Lint with auto-fix:
 ```bash
-markdownlint-rs --fix
+mdlint --fix
 ```
 
 ### Command-Line Options
 
 ```
-markdownlint-rs [OPTIONS] [PATTERNS]...
+mdlint [OPTIONS] [PATTERNS]...
 
 Arguments:
   [PATTERNS]...  Glob patterns for files to lint (defaults to current directory)
@@ -163,27 +163,27 @@ Options:
 
 **Lint with custom config file:**
 ```bash
-markdownlint-rs --config .markdownlint.json
+mdlint --config .markdownlint.json
 ```
 
 **Output as JSON:**
 ```bash
-markdownlint-rs --format json
+mdlint --format json
 ```
 
 **Lint specific glob patterns:**
 ```bash
-markdownlint-rs "**/*.md" "!node_modules/**"
+mdlint "**/*.md" "!node_modules/**"
 ```
 
 **Fix issues automatically:**
 ```bash
-markdownlint-rs --fix docs/
+mdlint --fix docs/
 ```
 
 **Disable color output (for CI):**
 ```bash
-markdownlint-rs --no-color
+mdlint --no-color
 ```
 
 ## Configuration
@@ -279,7 +279,7 @@ See the [markdownlint rules documentation](https://github.com/DavidAnson/markdow
 
 Use exit codes in CI/CD pipelines:
 ```bash
-markdownlint-rs || exit 1  # Fail build on linting errors
+mdlint || exit 1  # Fail build on linting errors
 ```
 
 ## Supported Rules


### PR DESCRIPTION
- Add [[bin]] section in Cargo.toml to set binary name to "mdlint"
- Update all workflow files to use new binary name
- Update README with new installation URLs and usage examples
- Update release checksums to reference mdlint-*.sha256

This makes the tool easier to use from the command line while keeping the package name as markdownlint-rs on crates.io.