### PR TITLE
Fix GitHub Actions permissions for release creation

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -58,6 +58,8 @@ jobs:
     name: Create Release
     needs: ci
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ steps.get_version.outputs.version }}
@@ -135,6 +137,8 @@ jobs:
     name: Build Release Binaries
     needs: create-release
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Add 'contents: write' permission to create-release and build-release jobs to allow creating releases and uploading assets.

Fixes: Resource not accessible by integration error