### PR TITLE
Support immutable releases in GitHub

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -55,7 +55,7 @@ jobs:
 
   # Only create release if CI passes
   create-release:
-    name: Create Release
+    name: Create Draft Release
     needs: ci
     runs-on: ubuntu-latest
     permissions:
@@ -63,7 +63,6 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ steps.get_version.outputs.version }}
-      release_created: ${{ steps.check_release.outputs.exists == 'false' }}
     steps:
       - name: Get version from tag
         id: get_version
@@ -71,27 +70,27 @@ jobs:
           echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Check if release already exists
-        id: check_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if gh release view ${{ github.ref_name }} --repo ${{ github.repository }} >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Release ${{ github.ref_name }} already exists, skipping creation"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "❌ Error: Release ${{ github.ref_name }} already exists"
+            echo ""
+            echo "With immutable releases enabled, you cannot modify existing releases."
+            echo "If you need to create a new release, use a different version tag."
+            exit 1
           fi
+          echo "✅ Release does not exist, proceeding with creation"
 
-      - name: Create Release
+      - name: Create Draft Release
         id: create_release
-        if: steps.check_release.outputs.exists == 'false'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref_name }}
           release_name: Release ${{ github.ref_name }}
-          draft: false
+          draft: true
           prerelease: false
           body: |
             Release ${{ github.ref_name }}
@@ -99,6 +98,16 @@ jobs:
             ## Installation
 
             Download the appropriate binary for your platform from the assets below.
+
+            ### From crates.io
+
+            ```bash
+            cargo install markdownlint-rs
+            ```
+
+            ### Binary Downloads
+
+            See assets below for pre-built binaries for your platform.
 
             ### Verify checksums
 
@@ -114,23 +123,12 @@ jobs:
             if ($expected -eq $actual) { "OK" } else { "FAILED" }
             ```
 
-      - name: Get existing release upload URL
-        id: get_existing_release
-        if: steps.check_release.outputs.exists == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          upload_url=$(gh release view ${{ github.ref_name }} --repo ${{ github.repository }} --json uploadUrl -q .uploadUrl)
-          echo "upload_url=$upload_url" >> $GITHUB_OUTPUT
+            ### Docker
 
-      - name: Set upload URL output
-        id: set_upload_url
-        run: |
-          if [[ "${{ steps.check_release.outputs.exists }}" == "true" ]]; then
-            echo "upload_url=${{ steps.get_existing_release.outputs.upload_url }}" >> $GITHUB_OUTPUT
-          else
-            echo "upload_url=${{ steps.create_release.outputs.upload_url }}" >> $GITHUB_OUTPUT
-          fi
+            ```bash
+            docker pull ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.version }}
+            ```
+
 
   # Build and upload release binaries
   build-release:
@@ -338,7 +336,6 @@ jobs:
   publish-crates-io:
     name: Publish to crates.io
     needs: [create-release, build-release]
-    if: needs.create-release.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -351,3 +348,20 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
+
+  # Publish the draft release (makes it immutable)
+  publish-release:
+    name: Publish Release
+    needs: [create-release, build-release, publish-docker, publish-crates-io]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit ${{ github.ref_name }} \
+            --repo ${{ github.repository }} \
+            --draft=false
+          echo "✅ Release ${{ github.ref_name }} published and is now immutable"


### PR DESCRIPTION
Changes the release workflow to be compatible with GitHub's immutable releases feature:

1. Create release as DRAFT initially
2. Upload all assets to the draft release
3. Publish Docker images and crates.io
4. Publish the release (makes it immutable)

Key changes:
- Release created with draft: true
- Remove "reuse existing release" logic - fail fast if release exists
- Add new publish-release job that publishes the draft
- Once published, release cannot be modified (immutable)

This ensures all assets are uploaded atomically before the release becomes publicly visible and immutable.