### PR TITLE
Skip manual strip for cross-compiled binaries

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -205,8 +205,8 @@ jobs:
         if: matrix.cross
         run: cross build --release --target ${{ matrix.target }}
 
-      - name: Strip binary (Linux and macOS)
-        if: matrix.os != 'windows-latest'
+      - name: Strip binary (Linux and macOS, native builds only)
+        if: matrix.os != 'windows-latest' && !matrix.cross
         run: strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
 
       - name: Generate SHA256 checksum (Linux and macOS)


### PR DESCRIPTION
The native strip command cannot handle ARM64 binaries on x86_64 hosts. Since Cargo.toml has 'strip = true' in the release profile, Cargo already strips binaries during build for all targets.

Skip the manual strip step for cross-compiled builds to avoid: 'Unable to recognise the format of the input file' error