### PR TITLE
Fix MD030 false positives with bold/italic text

### DIFF
--- a/src/lint/rules/md030.rs
+++ b/src/lint/rules/md030.rs
@@ -61,10 +61,10 @@ impl Rule for MD030 {
                 if let Some(line) = parser.lines().get(line_num - 1) {
                     let trimmed_start = line.len() - line.trim_start().len();
                     // If the emphasis starts right at the trimmed position, exclude this line
-                    if let Some(&line_start_offset) = line_offsets.get(line_num - 1) {
-                        if range.start == line_start_offset + trimmed_start {
-                            emphasis_start_lines.insert(line_num);
-                        }
+                    if let Some(&line_start_offset) = line_offsets.get(line_num - 1)
+                        && range.start == line_start_offset + trimmed_start
+                    {
+                        emphasis_start_lines.insert(line_num);
                     }
                 }
             }
@@ -232,7 +232,11 @@ mod tests {
         let rule = MD030;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 0, "Bold/emphasis should not trigger MD030");
+        assert_eq!(
+            violations.len(),
+            0,
+            "Bold/emphasis should not trigger MD030"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The MD030 rule was incorrectly identifying emphasis markers (**bold** and *italic*) as list markers, causing false positives and incorrect fixes. For example, "**Slice-specific schemas**" was being transformed to "* *Slice-specific schemas**".

Fixed by using a hybrid approach:
1. Parse the AST to identify lines starting with emphasis/strong tags
2. Exclude those lines from list marker detection
3. Use string matching for detecting malformed list items (e.g., "*Item" without space) which aren't valid CommonMark but should still be detected by MD030

All tests pass and the reported bug is now fixed.