### PR TITLE
Detect broken ordered list continuations

### DIFF
--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -480,7 +480,7 @@ impl FormatterState {
                 self.out.push_str(&bq);
             }
             // Escape leading characters that would be re-parsed as structural elements.
-            if needs_line_escape(first) {
+            if needs_line_escape(first, false) {
                 self.out.push('\\');
             }
             self.out.push_str(first);
@@ -495,7 +495,8 @@ impl FormatterState {
             self.out.push_str(continuation_prefix);
             self.out.push_str(&bq);
             // Escape leading characters that would be re-parsed as structural elements.
-            if needs_line_escape(line) {
+            // Use continuation mode: only `1.` needs escaping (CommonMark §5.2).
+            if needs_line_escape(line, true) {
                 self.out.push('\\');
             }
             self.out.push_str(line);
@@ -534,7 +535,12 @@ impl FormatterState {
 /// as a structural Markdown block element on re-parse, and therefore needs a
 /// leading `\` escape.  This matters for first lines of paragraphs and for
 /// soft-break continuation lines that are emitted as separate output lines.
-fn needs_line_escape(line: &str) -> bool {
+///
+/// When `is_continuation` is true, the line is a soft-break continuation
+/// inside a paragraph.  In CommonMark only `1.` / `1)` can interrupt a
+/// paragraph, so other ordered-list markers (2., 6., etc.) must NOT be
+/// escaped — escaping them hides real formatting problems from the linter.
+fn needs_line_escape(line: &str, is_continuation: bool) -> bool {
     if line.is_empty() {
         return false;
     }
@@ -573,7 +579,9 @@ fn needs_line_escape(line: &str) -> bool {
         return true;
     }
 
-    // Ordered list marker: one or more ASCII digits followed by . or ) and then space/tab/end
+    // Ordered list marker: one or more ASCII digits followed by . or ) and then space/tab/end.
+    // On continuation lines only `1.` / `1)` can interrupt a paragraph (CommonMark spec §5.2),
+    // so we must not escape other numbers — doing so hides broken-list errors from the linter.
     {
         let digits: String = line.chars().take_while(|c| c.is_ascii_digit()).collect();
         if !digits.is_empty() {
@@ -581,7 +589,9 @@ fn needs_line_escape(line: &str) -> bool {
             if let Some(after_marker) = rest.strip_prefix(['.', ')'])
                 && (after_marker.is_empty() || after_marker.starts_with([' ', '\t']))
             {
-                return true;
+                if !is_continuation || digits == "1" {
+                    return true;
+                }
             }
         }
     }

--- a/src/lint/rules/md032.rs
+++ b/src/lint/rules/md032.rs
@@ -53,13 +53,33 @@ impl Rule for MD032 {
                     if line_num > 0 {
                         let prev_line = &lines[line_num - 1];
                         if !prev_line.trim().is_empty() {
-                            violations.push(Violation {
-                                line: line_num + 1,
-                                column: Some(1),
-                                rule: self.name().to_string(),
-                                message: "List should be surrounded by blank lines".to_string(),
-                                fix: None,
-                            });
+                            // Detect broken ordered list continuation: a line that
+                            // looks like an ordered list item (e.g. "6.") following
+                            // non-list text won't be parsed as a list item because
+                            // only "1." can interrupt a paragraph (CommonMark §5.2).
+                            if marker == ListMarker::Ordered && !starts_with_one(trimmed) {
+                                // Report on the interrupting line (previous line),
+                                // not the list-like line — that's where the break is.
+                                violations.push(Violation {
+                                    line: line_num, // previous line (0-indexed → 1-indexed)
+                                    column: Some(1),
+                                    rule: self.name().to_string(),
+                                    message:
+                                        "Line breaks ordered list continuation; subsequent \
+                                         numbered items are parsed as text, not list items"
+                                            .to_string(),
+                                    fix: None,
+                                });
+                            } else {
+                                violations.push(Violation {
+                                    line: line_num + 1,
+                                    column: Some(1),
+                                    rule: self.name().to_string(),
+                                    message: "List should be surrounded by blank lines"
+                                        .to_string(),
+                                    fix: None,
+                                });
+                            }
                         }
                     }
                 } else if Some(marker) != current_marker {
@@ -131,6 +151,13 @@ impl Rule for MD032 {
     }
 }
 
+/// Returns true if the line starts with `1.` or `1)` (the only ordered marker
+/// that can interrupt a paragraph in CommonMark).
+fn starts_with_one(trimmed: &str) -> bool {
+    let check = trimmed.strip_prefix('\\').unwrap_or(trimmed);
+    check.starts_with("1. ") || check.starts_with("1) ")
+}
+
 fn get_list_marker(trimmed: &str) -> Option<ListMarker> {
     // Check for unordered list markers
     if trimmed.starts_with("* ") {
@@ -143,9 +170,14 @@ fn get_list_marker(trimmed: &str) -> Option<ListMarker> {
         return Some(ListMarker::Dash);
     }
 
-    // Check for ordered list markers
-    if let Some(dot_pos) = trimmed.find(". ") {
-        let prefix = &trimmed[..dot_pos];
+    // Check for ordered list markers (also detect escaped markers like \6.)
+    let check = if let Some(stripped) = trimmed.strip_prefix('\\') {
+        stripped
+    } else {
+        trimmed
+    };
+    if let Some(dot_pos) = check.find(". ") {
+        let prefix = &check[..dot_pos];
         if !prefix.is_empty() && prefix.chars().all(|c| c.is_ascii_digit()) {
             return Some(ListMarker::Ordered);
         }


### PR DESCRIPTION
## Summary

- **Formatter fix**: Stop escaping non-`1` ordered list markers (e.g. `6.`, `3.`) on paragraph continuation lines. In CommonMark §5.2, only `1.` can interrupt a paragraph, so escaping other numbers is incorrect and hides real errors from the linter.
- **Linter fix (MD032)**: Detect when non-list text breaks an ordered list continuation. Lines like `[... and we wait]` between items 5 and 6 cause subsequent numbered items to be absorbed as paragraph text instead of being parsed as list items. The violation now points at the interrupting line with a clear message.

## Example

Input:
```markdown
5. spawn a Waiter goroutine

[... and we wait]
6. when the process exits
```

Before: no error detected (formatter escaped `6.` → `\6.`, hiding the issue)

After:
```
12:1: MD032 Line breaks ordered list continuation; subsequent numbered items are parsed as text, not list items
     | [... and we wait]
     | ^
```

## Test plan

- [x] All 384 unit tests pass
- [x] Formatter proptest (idempotency, no panics, no trailing whitespace) passes
- [x] Integration and formatter tests pass
- [x] Manual verification on real markdown files with broken list continuations

🤖 Generated with [Claude Code](https://claude.com/claude-code)