### PR TITLE
Feature: add `--no-fix` flag

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -123,8 +123,11 @@ pub struct CheckArgs {
     #[arg(long, hide = true, conflicts_with = "respect_ignore")]
     pub no_respect_ignore: bool,
 
-    #[arg(long, help = "Apply auto-fixes where possible")]
+    #[arg(long, help = "Apply auto-fixes where possible", overrides_with = "no_fix")]
     pub fix: bool,
+
+    #[arg(long, hide = true, overrides_with = "fix")]
+    pub no_fix: bool,
 
     #[arg(
         long,
@@ -175,6 +178,14 @@ impl CheckArgs {
 
     pub fn should_respect_ignore(&self) -> bool {
         !self.no_respect_ignore
+    }
+
+    pub fn should_fix(&self) -> Option<bool> {
+        match (self.fix, self.no_fix) {
+            (true, _) => Some(true),
+            (_, true) => Some(false),
+            (false, false) => None,
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn run() -> Result<bool> {
 
 fn run_check(args: &CheckArgs, config: Config, use_color: bool, verbose: bool) -> Result<bool> {
     let excludes = merge_excludes(&args.exclude, &config.exclude);
-    let should_fix = args.fix || config.fix;
+    let should_fix = args.should_fix().unwrap_or(config.fix);
     let files = find_files(&args.files(), &excludes, args.should_respect_ignore())?;
 
     if files.is_empty() {


### PR DESCRIPTION
Add the possibility to overwrite the config default and run checks without error fixing.

This PR resolves #21. See issue description for more information.