### PR TITLE
Fix link references

### DIFF
--- a/src/lint/rules/md034.rs
+++ b/src/lint/rules/md034.rs
@@ -27,19 +27,13 @@ impl Rule for MD034 {
 
         // Get code lines to skip (both blocks and inline code can contain URLs)
         let code_lines = parser.get_code_line_numbers();
+        let ref_def_lines = parser.get_ref_def_line_numbers();
 
         for (line_num, line) in parser.lines().iter().enumerate() {
             let line_number = line_num + 1;
 
-            // Skip if line is in a code block or inline code
-            if code_lines.contains(&line_number) {
-                continue;
-            }
-
-            // Skip link reference definitions (`[label]: https://example.com`); the
-            // URL there is the definition's destination, not a bare URL in prose.
-            let trimmed = line.trim();
-            if trimmed.starts_with('[') && trimmed.find("]:").is_some() {
+            // Skip code and link reference definitions — URLs in these are not bare
+            if code_lines.contains(&line_number) || ref_def_lines.contains(&line_number) {
                 continue;
             }
 

--- a/src/lint/rules/md034.rs
+++ b/src/lint/rules/md034.rs
@@ -36,6 +36,13 @@ impl Rule for MD034 {
                 continue;
             }
 
+            // Skip link reference definitions (`[label]: https://example.com`); the
+            // URL there is the definition's destination, not a bare URL in prose.
+            let trimmed = line.trim();
+            if trimmed.starts_with('[') && trimmed.find("]:").is_some() {
+                continue;
+            }
+
             // Skip lines that are inside markdown link syntax
             for cap in url_regex.captures_iter(line) {
                 if let Some(url_match) = cap.get(1) {
@@ -122,5 +129,20 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         assert_eq!(violations.len(), 0, "URLs in inline code should be ignored");
+    }
+
+    #[test]
+    fn test_url_in_reference_definition() {
+        // Regression test for https://github.com/swanysimon/mdlint/issues/53
+        let content = "Here a [reference] is used.\n\n[reference]: https://example.com/";
+        let parser = MarkdownParser::new(content);
+        let rule = MD034;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(
+            violations.len(),
+            0,
+            "URL in a link reference definition should not be flagged as bare"
+        );
     }
 }

--- a/src/lint/rules/md052.rs
+++ b/src/lint/rules/md052.rs
@@ -1,9 +1,8 @@
 use crate::lint::rule::Rule;
 use crate::markdown::MarkdownParser;
 use crate::types::Violation;
-use regex::Regex;
+use pulldown_cmark::{Event, LinkType, Tag};
 use serde_json::Value;
-use std::collections::HashSet;
 
 pub struct MD052;
 
@@ -23,46 +22,30 @@ impl Rule for MD052 {
     fn check(&self, parser: &MarkdownParser, _config: Option<&Value>) -> Vec<Violation> {
         let mut violations = Vec::new();
 
-        // First pass: collect all defined reference labels
-        let mut defined_labels: HashSet<String> = HashSet::new();
+        // A broken-link callback forces pulldown-cmark to still emit an event for
+        // reference-style links/images with no matching definition, tagging their
+        // `LinkType` as the `*Unknown` variant instead of silently treating them as
+        // plain text. This lets shortcut (`[label]`) and collapsed (`[label][]`)
+        // forms be checked alongside the full `[text][label]` form.
+        for (event, range) in parser.parse_with_broken_links() {
+            let (is_image, link_type, id) = match event {
+                Event::Start(Tag::Link { link_type, id, .. }) => (false, link_type, id),
+                Event::Start(Tag::Image { link_type, id, .. }) => (true, link_type, id),
+                _ => continue,
+            };
 
-        for line in parser.lines() {
-            // Match reference definitions: [label]: url
-            let trimmed = line.trim();
-            if trimmed.starts_with('[')
-                && let Some(end_bracket) = trimmed.find("]:")
-            {
-                let label = &trimmed[1..end_bracket];
-                defined_labels.insert(label.to_lowercase());
-            }
-        }
-
-        // Second pass: find reference-style links and images in raw text
-        // Pattern: [text][label] or ![alt][label]
-        let regex_link = Regex::new(r"!?\[([^\]]+)\]\[([^\]]+)\]").unwrap();
-
-        for (line_num, line) in parser.lines().iter().enumerate() {
-            let line_number = line_num + 1;
-
-            for cap in regex_link.captures_iter(line) {
-                let label = cap.get(2).unwrap().as_str().to_lowercase();
-
-                if !defined_labels.contains(&label) {
-                    let is_image = cap.get(0).unwrap().as_str().starts_with('!');
-                    let item_type = if is_image { "image" } else { "link" };
-
-                    violations.push(Violation {
-                        line: line_number,
-                        column: Some(1),
-                        rule: self.name().to_string(),
-                        message: format!(
-                            "Reference {} label '{}' is not defined",
-                            item_type,
-                            cap.get(2).unwrap().as_str()
-                        ),
-                        fix: None,
-                    });
-                }
+            if matches!(
+                link_type,
+                LinkType::ReferenceUnknown | LinkType::CollapsedUnknown | LinkType::ShortcutUnknown
+            ) {
+                let item_type = if is_image { "image" } else { "link" };
+                violations.push(Violation {
+                    line: parser.offset_to_line(range.start),
+                    column: Some(1),
+                    rule: self.name().to_string(),
+                    message: format!("Reference {item_type} label '{id}' is not defined"),
+                    fix: None,
+                });
             }
         }
 
@@ -129,5 +112,37 @@ mod tests {
 
         // Labels should be case-insensitive
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_shortcut_reference_undefined() {
+        // Regression test for https://github.com/swanysimon/mdlint/issues/53
+        let content = "Here a [reference] is unused.";
+        let parser = MarkdownParser::new(content);
+        let rule = MD052;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("reference"));
+    }
+
+    #[test]
+    fn test_shortcut_reference_defined() {
+        let content = "Here a [reference] is used.\n\n[reference]: https://example.com/";
+        let parser = MarkdownParser::new(content);
+        let rule = MD052;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_collapsed_reference_undefined() {
+        let content = "[Link][]";
+        let parser = MarkdownParser::new(content);
+        let rule = MD052;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 1);
     }
 }

--- a/src/lint/rules/md053.rs
+++ b/src/lint/rules/md053.rs
@@ -3,7 +3,7 @@ use crate::markdown::MarkdownParser;
 use crate::types::Violation;
 use pulldown_cmark::{Event, LinkType, Tag};
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 pub struct MD053;
 
@@ -23,21 +23,9 @@ impl Rule for MD053 {
     fn check(&self, parser: &MarkdownParser, _config: Option<&Value>) -> Vec<Violation> {
         let mut violations = Vec::new();
 
-        // First pass: collect all defined reference labels with their line numbers
-        let mut defined_labels: HashMap<String, usize> = HashMap::new();
+        let defined_labels = parser.get_ref_defs();
 
-        for (line_num, line) in parser.lines().iter().enumerate() {
-            let line_number = line_num + 1;
-            let trimmed = line.trim();
-            if trimmed.starts_with('[')
-                && let Some(end_bracket) = trimmed.find("]:")
-            {
-                let label = &trimmed[1..end_bracket];
-                defined_labels.insert(label.to_lowercase(), line_number);
-            }
-        }
-
-        // Second pass: find reference-style links and images actually used. Parses
+        // Find reference-style links and images actually used. Parses
         // events rather than raw text so shortcut (`[label]`) and collapsed
         // (`[label][]`) forms are counted alongside the full `[text][label]` form.
         let mut used_labels: HashSet<String> = HashSet::new();
@@ -63,9 +51,9 @@ impl Rule for MD053 {
 
         // Find unused definitions
         for (label, line_number) in defined_labels {
-            if !used_labels.contains(&label) {
+            if !used_labels.contains(label.as_str()) {
                 violations.push(Violation {
-                    line: line_number,
+                    line: *line_number,
                     column: Some(1),
                     rule: self.name().to_string(),
                     message: format!(

--- a/src/lint/rules/md053.rs
+++ b/src/lint/rules/md053.rs
@@ -1,7 +1,7 @@
 use crate::lint::rule::Rule;
 use crate::markdown::MarkdownParser;
 use crate::types::Violation;
-use regex::Regex;
+use pulldown_cmark::{Event, LinkType, Tag};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 
@@ -37,15 +37,27 @@ impl Rule for MD053 {
             }
         }
 
-        // Second pass: find reference-style links and images in raw text
-        // Pattern: [text][label] or ![alt][label]
+        // Second pass: find reference-style links and images actually used. Parses
+        // events rather than raw text so shortcut (`[label]`) and collapsed
+        // (`[label][]`) forms are counted alongside the full `[text][label]` form.
         let mut used_labels: HashSet<String> = HashSet::new();
-        let regex_link = Regex::new(r"!?\[([^\]]+)\]\[([^\]]+)\]").unwrap();
 
-        for line in parser.lines() {
-            for cap in regex_link.captures_iter(line) {
-                let label = cap.get(2).unwrap().as_str().to_lowercase();
-                used_labels.insert(label);
+        for event in parser.parse() {
+            let (link_type, id) = match event {
+                Event::Start(Tag::Link { link_type, id, .. }) => (link_type, id),
+                Event::Start(Tag::Image { link_type, id, .. }) => (link_type, id),
+                _ => continue,
+            };
+            if matches!(
+                link_type,
+                LinkType::Reference
+                    | LinkType::ReferenceUnknown
+                    | LinkType::Collapsed
+                    | LinkType::CollapsedUnknown
+                    | LinkType::Shortcut
+                    | LinkType::ShortcutUnknown
+            ) {
+                used_labels.insert(id.to_lowercase());
             }
         }
 
@@ -122,6 +134,26 @@ mod tests {
     #[test]
     fn test_all_used() {
         let content = "[link1]: url1\n[link2]: url2\n\n[A][link1] [B][link2]";
+        let parser = MarkdownParser::new(content);
+        let rule = MD053;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_shortcut_reference_used() {
+        let content = "Here a [reference] is used.\n\nAnd below it is defined:\n\n[reference]: https://example.com/";
+        let parser = MarkdownParser::new(content);
+        let rule = MD053;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_collapsed_reference_used() {
+        let content = "[link]: https://example.com\n\n[Link][]";
         let parser = MarkdownParser::new(content);
         let rule = MD053;
         let violations = rule.check(&parser, None);

--- a/src/markdown/parser.rs
+++ b/src/markdown/parser.rs
@@ -1,4 +1,4 @@
-use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{BrokenLink, CowStr, Event, Options, Parser, Tag, TagEnd};
 use std::collections::HashSet;
 use std::ops::Range;
 
@@ -57,6 +57,19 @@ impl<'a> MarkdownParser<'a> {
 
     pub fn parse_with_offsets(&self) -> impl Iterator<Item = (Event<'a>, Range<usize>)> {
         Parser::new_ext(self.content, mk_options()).into_offset_iter()
+    }
+
+    /// Like `parse_with_offsets`, but resolves otherwise-broken reference links
+    /// (undefined labels) by flagging their `LinkType` as the corresponding
+    /// `*Unknown` variant instead of silently dropping the event as plain text.
+    /// Used by rules that need to detect undefined reference links/images.
+    pub fn parse_with_broken_links(&self) -> impl Iterator<Item = (Event<'a>, Range<usize>)> + 'a {
+        Parser::new_with_broken_link_callback(
+            self.content,
+            mk_options(),
+            Some(|_broken: BrokenLink| Some((CowStr::from(""), CowStr::from("")))),
+        )
+        .into_offset_iter()
     }
 
     pub fn offset_to_line(&self, offset: usize) -> usize {

--- a/src/markdown/parser.rs
+++ b/src/markdown/parser.rs
@@ -14,6 +14,8 @@ pub struct MarkdownParser<'a> {
     code_lines: HashSet<usize>,
     /// Byte ranges of all code blocks and inline code spans.
     code_ranges: Vec<Range<usize>>,
+    /// Lines (1-indexed) that are part of a link reference definition (`[label]: url`).
+    ref_def_lines: HashSet<usize>,
 }
 
 impl<'a> MarkdownParser<'a> {
@@ -21,6 +23,7 @@ impl<'a> MarkdownParser<'a> {
         let lines: Vec<&'a str> = content.lines().collect();
         let line_offsets = build_line_offsets(content);
         let (code_block_lines, code_lines, code_ranges) = build_code_info(content, &line_offsets);
+        let ref_def_lines = build_ref_def_lines(content, &line_offsets);
         Self {
             content,
             lines,
@@ -28,6 +31,7 @@ impl<'a> MarkdownParser<'a> {
             code_block_lines,
             code_lines,
             code_ranges,
+            ref_def_lines,
         }
     }
 
@@ -104,6 +108,12 @@ impl<'a> MarkdownParser<'a> {
     /// inline code spans. Result is precomputed in `new()` — O(1) to access.
     pub fn get_code_ranges(&self) -> &[Range<usize>] {
         &self.code_ranges
+    }
+
+    /// Returns the 1-indexed line numbers that form link reference definitions
+    /// (`[label]: url`). Result is precomputed in `new()` — O(1) to access.
+    pub fn get_ref_def_line_numbers(&self) -> &HashSet<usize> {
+        &self.ref_def_lines
     }
 
     /// Converts a (1-indexed) line number and 0-indexed byte offset within that
@@ -215,6 +225,22 @@ fn build_code_info(
     }
 
     (code_block_lines, code_lines, code_ranges)
+}
+
+/// Collects all 1-indexed line numbers that belong to link reference definitions.
+/// Uses `Parser::reference_definitions()` which is populated before the first event
+/// is consumed, so we only need to create the parser (not iterate it).
+fn build_ref_def_lines(content: &str, line_offsets: &[usize]) -> HashSet<usize> {
+    let parser = Parser::new_ext(content, mk_options());
+    let mut lines = HashSet::new();
+    for (_, link_def) in parser.reference_definitions().iter() {
+        let start = line_from_offset(link_def.span.start, line_offsets);
+        let end = line_from_offset(link_def.span.end.saturating_sub(1), line_offsets);
+        for line in start..=end {
+            lines.insert(line);
+        }
+    }
+    lines
 }
 
 #[cfg(test)]
@@ -403,5 +429,16 @@ mod tests {
         assert_eq!(parser.offset_to_position(2), (1, 3));
         assert_eq!(parser.offset_to_position(5), (2, 1));
         assert_eq!(parser.offset_to_position(7), (2, 3));
+    }
+
+    #[test]
+    fn test_ref_def_line_numbers() {
+        let content = "Text\n\n[foo]: https://example.com\n\nMore text";
+        let parser = MarkdownParser::new(content);
+        let ref_def_lines = parser.get_ref_def_line_numbers();
+
+        assert!(ref_def_lines.contains(&3), "ref def line should be marked");
+        assert!(!ref_def_lines.contains(&1), "prose should not be marked");
+        assert!(!ref_def_lines.contains(&5), "prose should not be marked");
     }
 }

--- a/src/markdown/parser.rs
+++ b/src/markdown/parser.rs
@@ -1,5 +1,5 @@
 use pulldown_cmark::{BrokenLink, CowStr, Event, Options, Parser, Tag, TagEnd};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 
 pub struct MarkdownParser<'a> {
@@ -16,6 +16,8 @@ pub struct MarkdownParser<'a> {
     code_ranges: Vec<Range<usize>>,
     /// Lines (1-indexed) that are part of a link reference definition (`[label]: url`).
     ref_def_lines: HashSet<usize>,
+    /// Map from normalised (lowercase) label to its 1-indexed line number.
+    ref_defs: HashMap<String, usize>,
 }
 
 impl<'a> MarkdownParser<'a> {
@@ -23,7 +25,7 @@ impl<'a> MarkdownParser<'a> {
         let lines: Vec<&'a str> = content.lines().collect();
         let line_offsets = build_line_offsets(content);
         let (code_block_lines, code_lines, code_ranges) = build_code_info(content, &line_offsets);
-        let ref_def_lines = build_ref_def_lines(content, &line_offsets);
+        let (ref_def_lines, ref_defs) = build_ref_def_info(content, &line_offsets);
         Self {
             content,
             lines,
@@ -32,6 +34,7 @@ impl<'a> MarkdownParser<'a> {
             code_lines,
             code_ranges,
             ref_def_lines,
+            ref_defs,
         }
     }
 
@@ -114,6 +117,12 @@ impl<'a> MarkdownParser<'a> {
     /// (`[label]: url`). Result is precomputed in `new()` — O(1) to access.
     pub fn get_ref_def_line_numbers(&self) -> &HashSet<usize> {
         &self.ref_def_lines
+    }
+
+    /// Returns a map of normalised (lowercase) label → 1-indexed line number for
+    /// every link reference definition in the document.
+    pub fn get_ref_defs(&self) -> &HashMap<String, usize> {
+        &self.ref_defs
     }
 
     /// Converts a (1-indexed) line number and 0-indexed byte offset within that
@@ -227,20 +236,26 @@ fn build_code_info(
     (code_block_lines, code_lines, code_ranges)
 }
 
-/// Collects all 1-indexed line numbers that belong to link reference definitions.
-/// Uses `Parser::reference_definitions()` which is populated before the first event
-/// is consumed, so we only need to create the parser (not iterate it).
-fn build_ref_def_lines(content: &str, line_offsets: &[usize]) -> HashSet<usize> {
+/// Collects link reference definition metadata in one pass over the parser's
+/// `reference_definitions()` map (populated before the first event is consumed).
+/// Returns (line-number set, label→line map); both use 1-indexed line numbers and
+/// normalised (lowercase) labels.
+fn build_ref_def_info(
+    content: &str,
+    line_offsets: &[usize],
+) -> (HashSet<usize>, HashMap<String, usize>) {
     let parser = Parser::new_ext(content, mk_options());
-    let mut lines = HashSet::new();
-    for (_, link_def) in parser.reference_definitions().iter() {
+    let mut line_set = HashSet::new();
+    let mut label_map = HashMap::new();
+    for (label, link_def) in parser.reference_definitions().iter() {
         let start = line_from_offset(link_def.span.start, line_offsets);
         let end = line_from_offset(link_def.span.end.saturating_sub(1), line_offsets);
         for line in start..=end {
-            lines.insert(line);
+            line_set.insert(line);
         }
+        label_map.insert(label.to_string(), start);
     }
-    lines
+    (line_set, label_map)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
None of the codebases I've worked with yet have used link references, but they should be supported. As pointed out by
https://github.com/swanysimon/mdlint/issues/53, this is not the case.

Fixes the parser to no longer use my regex parser and instead rely on pulldown-cmark to figure out what is what.