### PR TITLE
Consolidate pending dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           cache-key: "lint"
 
       - name: Install mise
-        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4
         env:
           MISE_TRUSTED_CONFIG_PATHS: ${{ github.workspace }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.97-alpine AS builder
+FROM rust:1.97-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088a8c3324d40900 AS builder
 
 # Docker provides these automatically based on --platform
 ARG TARGETARCH

--- a/renovate.json
+++ b/renovate.json
@@ -36,15 +36,8 @@
       "pinDigests": true
     },
     {
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "pin",
-        "digest",
-        "lockFileMaintenance",
-        "rollback",
-        "replacement"
+      "matchPackageNames": [
+        "*"
       ],
       "groupName": "all dependencies",
       "groupSlug": "all-dependencies"


### PR DESCRIPTION
## Summary
- Pins the `rust:1.97-alpine` Docker base image to its digest (from #60)
- Bumps `jdx/mise-action` to its latest digest (from #61)
- Fixes the `renovate.json` group rule so Dockerfile/Actions digest and pin updates stop splitting into separate PRs going forward — `matchUpdateTypes` was missing `pinDigest` (distinct from `digest`), so it's reverted to the broader `matchPackageNames: ["*"]` match used before #d9c09d6

The `Cargo.lock` refresh from #59 is not included: it's a no-op against current `main` (identical content — already covered by the prior "Update all dependencies" merge), so it's superseded rather than combined.

Supersedes #59, #60, #61.

## Test plan
- [x] `prek run -a` passes (rustfmt, clippy, tests, mdlint dogfood, tombi, hadolint, shellcheck)
- [x] `renovate.json` validated as well-formed JSON