### PR TITLE
Fix MD055 firing on pipe characters inside inline code spans

### DIFF
--- a/src/glob/walker.rs
+++ b/src/glob/walker.rs
@@ -116,9 +116,15 @@ mod tests {
     fn test_gitignore_respect() {
         let temp_dir = TempDir::new().unwrap();
 
+        // Clear GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE: when this test runs from inside a git
+        // hook (e.g. `prek`/`pre-commit` invoked by `git commit`), those are set to the outer
+        // repository and leak into this subprocess, breaking `git init` in temp_dir.
         std::process::Command::new("git")
             .args(["init"])
             .current_dir(temp_dir.path())
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
 

--- a/src/lint/rules/md055.rs
+++ b/src/lint/rules/md055.rs
@@ -28,6 +28,7 @@ impl Rule for MD055 {
         let mut violations = Vec::new();
         let mut first_style: Option<&str> = None;
         let code_block_lines = parser.get_code_block_line_numbers();
+        let code_ranges = parser.get_code_ranges();
 
         for (line_num, line) in parser.lines().iter().enumerate() {
             let line_number = line_num + 1;
@@ -36,8 +37,14 @@ impl Rule for MD055 {
                 continue;
             }
 
-            // Check if line is a table row (contains pipes)
-            if !line.contains('|') {
+            // Check if line is a table row: it must contain a pipe that isn't
+            // inside an inline code span (e.g. `a | b`), otherwise it's just
+            // prose that happens to mention a pipe character.
+            let has_real_pipe = line.match_indices('|').any(|(byte_offset, _)| {
+                let absolute = parser.line_offset_to_absolute(line_number, byte_offset);
+                !code_ranges.iter().any(|range| range.contains(&absolute))
+            });
+            if !has_real_pipe {
                 continue;
             }
 
@@ -221,5 +228,30 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_pipe_only_in_inline_code_span_ignored() {
+        // https://github.com/swanysimon/mdlint/issues/65
+        let content = "# Example\n\nThis is a line with an `a | b` inline code span.";
+        let parser = MarkdownParser::new(content);
+        let rule = MD055;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_real_table_with_code_span_pipe_still_flagged() {
+        // A genuine table row whose leading/trailing pipes are real, even
+        // though it also contains a code span with an internal pipe.
+        let content = "Col1 | `a|b`\n-----|-----\nA | B";
+        let parser = MarkdownParser::new(content);
+        let rule = MD055;
+        let config = serde_json::json!({ "style": "leading_and_trailing" });
+        let violations = rule.check(&parser, Some(&config));
+
+        // 3 rows x 2 violations each (missing leading and trailing pipe)
+        assert_eq!(violations.len(), 6);
     }
 }


### PR DESCRIPTION
## Summary

- MD055 ("Table pipe style") scanned every line for a `|` character to decide whether it was a table row, with no awareness of inline code spans. A line like `` This is a line with an `a | b` inline code span. `` contains a `|` only inside a code span (`` `a | b` ``), not as a real table pipe, but MD055 treated it as a headerless table row and flagged "missing leading pipe" / "missing trailing pipe".
- Fixed by checking each candidate `|` against `MarkdownParser::get_code_ranges()` (byte ranges covering fenced code blocks and inline code spans) via `line_offset_to_absolute`. A line is now only treated as a table row if it has at least one `|` that falls outside every code range. Lines whose only pipes live inside inline code spans are skipped, just like fully-fenced code block lines already were.
- Also fixed a pre-existing flaky test, `glob::walker::tests::test_gitignore_respect`: it ran `git init` in a temp dir without clearing `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`, so when `cargo test` runs from inside a git hook (e.g. via `prek`/`pre-commit` during `git commit`), those inherited env vars broke the nested `git init`, making the test non-deterministic under `prek run -a`. Unrelated to MD055, but needed to get `prek run -a` passing consistently to commit this change.

Closes #65

## Test plan

- [x] `cargo test md055 --lib` — new test reproducing the issue's exact repro (`This is a line with an \`a | b\` inline code span.`) asserts zero violations; new test with a real table row that also contains a code span with an internal pipe asserts the row is still flagged correctly
- [x] `cargo test` — full suite passes
- [x] `prek run -a` — all hooks pass clean (trailing-whitespace, clippy `-D warnings`, rustfmt, cargo test, mdlint dogfooding)