### PR TITLE
Fix --select/--ignore not filtering rules

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -78,4 +78,111 @@ impl Config {
     pub fn config(&self) -> &HashMap<String, RuleConfig> {
         &self.rules
     }
+
+    /// Apply `--select`/`--ignore` CLI overrides on top of the loaded config.
+    ///
+    /// `select` (if non-empty and not `ALL`, case-insensitive) restricts linting to just the
+    /// listed rules: `default_enabled` is turned off and each rule gets a bare `Enabled(true)`
+    /// entry, unless a more specific `RuleConfig::Config(..)` already exists for it (so
+    /// config-file rule parameters, e.g. MD013's `line_length`, survive `--select`).
+    ///
+    /// `ignore` unconditionally force-disables the listed rules, overriding both the config
+    /// file and `--select`.
+    ///
+    /// Empty `select`/`ignore` is a no-op.
+    #[must_use]
+    pub fn apply_rule_filters(mut self, select: &[String], ignore: &[String]) -> Self {
+        let select_all = select.iter().any(|code| code.eq_ignore_ascii_case("all"));
+        if !select.is_empty() && !select_all {
+            self.default_enabled = false;
+            for code in select {
+                self.rules
+                    .entry(code.to_uppercase())
+                    .or_insert(RuleConfig::Enabled(true));
+            }
+        }
+
+        for code in ignore {
+            self.rules
+                .insert(code.to_uppercase(), RuleConfig::Enabled(false));
+        }
+
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn select_empty_is_noop() {
+        let config = Config::default().apply_rule_filters(&[], &[]);
+        assert!(config.default_enabled);
+        assert!(config.rules.is_empty());
+    }
+
+    #[test]
+    fn select_restricts_to_listed_rules() {
+        let config = Config::default().apply_rule_filters(&["md001".to_owned()], &[]);
+        assert!(!config.default_enabled);
+        assert!(matches!(
+            config.rules.get("MD001"),
+            Some(RuleConfig::Enabled(true))
+        ));
+        assert_eq!(config.rules.len(), 1);
+    }
+
+    #[test]
+    fn select_all_is_noop() {
+        let config = Config::default().apply_rule_filters(&["ALL".to_owned()], &[]);
+        assert!(config.default_enabled);
+        assert!(config.rules.is_empty());
+    }
+
+    #[test]
+    fn select_preserves_existing_rule_config() {
+        let mut base = Config::default();
+        let mut params = HashMap::new();
+        params.insert("line_length".to_owned(), toml::Value::Integer(100));
+        base.rules
+            .insert("MD013".to_owned(), RuleConfig::Config(params));
+
+        let config = base.apply_rule_filters(&["MD013".to_owned()], &[]);
+        match config.rules.get("MD013") {
+            Some(RuleConfig::Config(params)) => {
+                assert_eq!(params.get("line_length"), Some(&toml::Value::Integer(100)));
+            }
+            other => panic!("expected preserved MD013 config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ignore_force_disables_rule() {
+        let mut base = Config::default();
+        base.rules
+            .insert("MD013".to_owned(), RuleConfig::Enabled(true));
+
+        let config = base.apply_rule_filters(&[], &["md013".to_owned()]);
+        assert!(matches!(
+            config.rules.get("MD013"),
+            Some(RuleConfig::Enabled(false))
+        ));
+    }
+
+    #[test]
+    fn ignore_wins_over_select() {
+        let config = Config::default().apply_rule_filters(
+            &["MD001".to_owned(), "MD013".to_owned()],
+            &["MD013".to_owned()],
+        );
+        assert!(matches!(
+            config.rules.get("MD001"),
+            Some(RuleConfig::Enabled(true))
+        ));
+        assert!(matches!(
+            config.rules.get("MD013"),
+            Some(RuleConfig::Enabled(false))
+        ));
+    }
 }

--- a/src/glob/walker.rs
+++ b/src/glob/walker.rs
@@ -119,6 +119,12 @@ mod tests {
         std::process::Command::new("git")
             .args(["init"])
             .current_dir(temp_dir.path())
+            // AIDEV: unset git env vars inherited from an outer git process (e.g. a
+            // pre-commit/prek hook), otherwise this `git init` reinitializes the OUTER repo
+            // (via inherited GIT_DIR/GIT_WORK_TREE) instead of creating one in temp_dir
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ fn run_check(args: &CheckArgs, config: Config, use_color: bool, verbose: bool) -
     let excludes = merge_excludes(&args.exclude, &config.exclude);
     let should_fix = args.should_fix().unwrap_or(config.fix);
     let files = find_files(&args.files(), &excludes, args.should_respect_ignore())?;
+    let config = config.apply_rule_filters(&args.select, &args.ignore);
 
     if files.is_empty() {
         eprintln!("No markdown files found");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,4 @@
-use mdlint::config::Config;
+use mdlint::config::{Config, RuleConfig};
 use mdlint::fix::Fixer;
 use mdlint::formatter;
 use mdlint::lint::LintEngine;
@@ -133,4 +133,38 @@ fn check_clean_file_has_no_violations() {
         non_trivial.is_empty(),
         "formatted file should have no violations (except MD013/MD043): {non_trivial:?}"
     );
+}
+
+// ── --select / --ignore filtering (issue #68) ──────────────────────────────────
+
+#[test]
+fn select_restricts_check_to_named_rule() {
+    // Line has both a heading-level skip (MD001) and a hard tab (MD010); --select MD001
+    // should report only MD001.
+    let content = "# Heading\n\n### Skipped level\n\n\tTabbed line\n";
+    let config = Config::default().apply_rule_filters(&["MD001".to_owned()], &[]);
+    let violations = LintEngine::new(config).lint_content(content).unwrap();
+    assert!(violations.iter().any(|v| v.rule == "MD001"));
+    assert!(violations.iter().all(|v| v.rule == "MD001"));
+}
+
+#[test]
+fn ignore_excludes_named_rule_only() {
+    let content = "# Heading\n\n### Skipped level\n\n\tTabbed line\n";
+    let config = Config::default().apply_rule_filters(&[], &["MD010".to_owned()]);
+    let violations = LintEngine::new(config).lint_content(content).unwrap();
+    assert!(violations.iter().any(|v| v.rule == "MD001"));
+    assert!(violations.iter().all(|v| v.rule != "MD010"));
+}
+
+#[test]
+fn ignore_overrides_config_file_enabling_the_rule() {
+    let content = "\tTabbed line\n";
+    let mut config = Config::default();
+    config
+        .rules
+        .insert("MD010".to_owned(), RuleConfig::Enabled(true));
+    let config = config.apply_rule_filters(&[], &["MD010".to_owned()]);
+    let violations = LintEngine::new(config).lint_content(content).unwrap();
+    assert!(violations.iter().all(|v| v.rule != "MD010"));
 }


### PR DESCRIPTION
## Summary

- `CheckArgs.select`/`.ignore` were parsed by clap but never consumed anywhere — `run_check` built the `LintEngine` straight from the loaded `Config`, so `mdlint check --select ...` / `--ignore ...` had no effect on which rules ran.
- Add `Config::apply_rule_filters(select, ignore)` (`src/config/types.rs`), wired into `run_check` (`src/main.rs`) before the engine is constructed:
  - `--select CODE,...`: restricts linting to just those rules (`default_enabled = false`, each selected rule gets a bare `Enabled(true)` unless a more specific `RuleConfig::Config(..)` already exists from the loaded TOML config, so parameters like MD013's `line_length` survive). `--select ALL` (case-insensitive) is a no-op, matching the flag's help text.
  - `--ignore CODE,...`: unconditionally force-disables the listed rules, overriding both the config file and `--select`.
  - Empty `select`/`ignore` (the default) is a no-op.
- Also fixed an unrelated pre-existing flake in `glob::walker::tests::test_gitignore_respect`: its `git init` subprocess inherited `GIT_DIR`/`GIT_WORK_TREE` from the outer git process when tests ran inside a pre-commit/prek hook, reinitializing the *outer* repo instead of the temp dir under test and causing the gitignore assertion to fail intermittently. Cleared those env vars for the subprocess.

Closes #68

## Test plan

- [x] New unit tests in `src/config/types.rs` covering `apply_rule_filters`: no-op on empty input, `--select` restricts to listed rules, `--select ALL` is a no-op, `--select` preserves existing `RuleConfig::Config` parameters, `--ignore` force-disables, `--ignore` wins over `--select`.
- [x] New end-to-end tests in `tests/integration.rs` building a `LintEngine` from a filtered `Config` and asserting on `lint_content` output (select restricts, ignore excludes, ignore overrides a config file that explicitly enables the rule).
- [x] Manually reproduced the issue's exact repro (`mdlint check --select MD001 example.md` / `--ignore MD013`) before and after the fix.
- [x] `cargo test` passes (5x in a row, including the previously-flaky gitignore test).
- [x] `prek run -a` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)