### PR TITLE
Fix mdlint format/check disagreement on nested lists

### DIFF
--- a/src/glob/walker.rs
+++ b/src/glob/walker.rs
@@ -119,6 +119,15 @@ mod tests {
         std::process::Command::new("git")
             .args(["init"])
             .current_dir(temp_dir.path())
+            // Pre-commit hooks (this test may run under one, via `prek`/`git commit`)
+            // set GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE for the outer repo; inherited
+            // by this child process, they make `git init` reuse the outer repo
+            // instead of creating a fresh one in temp_dir, so no .git ever appears
+            // there and the .gitignore below is silently ignored.
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_PREFIX")
             .output()
             .unwrap();
 

--- a/src/lint/rules/md032.rs
+++ b/src/lint/rules/md032.rs
@@ -47,7 +47,14 @@ impl Rule for MD032 {
                     .expect("non-empty, checked above")
                     .is_whitespace();
 
-            if let Some(marker) = list_marker {
+            if list_marker.is_some() && in_list && is_indented {
+                // Indented list-marker line while already inside a list: this is a
+                // nested sub-list, not a sibling list at the same level. CommonMark
+                // and markdownlint don't require blank lines around nested lists —
+                // only around the outermost list — so treat it like any other
+                // indented continuation line and leave the enclosing list's
+                // marker/state untouched.
+            } else if let Some(marker) = list_marker {
                 if !in_list {
                     // Starting a new list
                     in_list = true;
@@ -294,5 +301,33 @@ mod tests {
         // + needs blank before/after (2 violations)
         // - needs blank before/after (2 violations)
         assert_eq!(violations.len(), 4);
+    }
+
+    #[test]
+    fn test_nested_list_different_marker_tight_not_flagged() {
+        // Regression test for issue #67: a nested ordered list directly under a
+        // bullet item, with no blank lines separating it from the parent item's
+        // text or the next sibling item, is not a set of separate top-level lists
+        // and must not be flagged. This is exactly the output `mdlint format`
+        // produces for this construct.
+        let content = "# Example\n\n- First item:\n  1. One\n  2. Two\n- Second item\n";
+        let parser = MarkdownParser::new(content);
+        let rule = MD032;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_nested_list_different_marker_loose_not_flagged() {
+        // Same construct as above, but with the blank lines that make the outer
+        // list loose. Both forms are valid CommonMark and neither should be
+        // flagged by MD032.
+        let content = "# Example\n\n- First item:\n\n  1. One\n  2. Two\n\n- Second item\n";
+        let parser = MarkdownParser::new(content);
+        let rule = MD032;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
     }
 }

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -127,6 +127,19 @@ fn nested_lists_preserved() {
 }
 
 #[test]
+fn nested_ordered_list_under_bullet_item_stays_tight() {
+    // Regression test for issue #67: a nested ordered list under a bullet item
+    // is formatted tight (no blank lines separating it from the parent item's
+    // text or the next sibling item), whether or not the source had blank
+    // lines around it. This canonical form must pass `mdlint check` (MD032)
+    // cleanly — see the matching MD032 tests in src/lint/rules/md032.rs.
+    assert_formats_to(
+        "# Example\n\n- First item:\n\n  1. One\n  2. Two\n\n- Second item\n",
+        "# Example\n\n- First item:\n  1. One\n  2. Two\n- Second item\n",
+    );
+}
+
+#[test]
 fn ordered_list_preserved() {
     assert_formats_to(
         "1. First\n2. Second\n3. Third\n",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -111,6 +111,24 @@ fn check_fix_replaces_hard_tabs() {
 }
 
 #[test]
+fn format_output_for_nested_list_passes_check() {
+    // Regression test for issue #67: `mdlint format`'s output for a bullet item
+    // containing a nested ordered sub-list must pass `mdlint check` cleanly.
+    // The formatter used to strip the blank lines around the nested list
+    // (intended, canonical behavior), but MD032 then misjudged the nested,
+    // differently-marked sub-list as a set of separate top-level lists,
+    // reporting spurious violations on the formatter's own output.
+    let content = "# Example\n\n- First item:\n\n  1. One\n  2. Two\n\n- Second item\n";
+    let formatted = formatter::format(content);
+    let engine = all_rules_engine();
+    let violations = engine.lint_content(&formatted).unwrap();
+    assert!(
+        violations.is_empty(),
+        "mdlint check should report no violations on mdlint format's output; got: {violations:?}\nformatted:\n{formatted}"
+    );
+}
+
+#[test]
 fn check_clean_file_has_no_violations() {
     let content = fixture("format/expected.md");
     let engine = LintEngine::new(Config {


### PR DESCRIPTION
## Summary

- `mdlint format` deliberately emits nested sub-lists tight (no blank line before a sublist — see `src/formatter/mod.rs` `Tag::List` handling, "A sublist follows its parent item text without a blank line"). This is intentional canonical style, confirmed against `FORMAT_SPEC.md` and existing formatter tests (e.g. `nested_lists_preserved`).
- MD032 (`src/lint/rules/md032.rs`) is a line-based scanner that detects list-marker lines and compares their marker against the "current" list's marker to decide if a blank line is required. It didn't account for indentation: an indented list-marker line (a nested sub-list, e.g. an ordered list nested inside a bullet item) with a *different* marker than its parent was misread as a new *sibling* top-level list, firing "List should be surrounded by blank lines" on every line of the construct.
- Net effect: `mdlint format`'s own tight-nested-list output failed `mdlint check` — a hard cross-subsystem invariant violation per this project's philosophy (formatter output must always pass `check` cleanly).

## Root cause

In MD032, an indented list-marker line hitting the `Some(marker) != current_marker` branch while already inside a list. Traced through the issue's repro:

```markdown
# Example

- First item:
  1. One
  2. Two
- Second item
```

`  1. One` (indented, marker `Ordered`) doesn't match the enclosing list's marker (`Dash`), so the old code treated it as "a new list" needing blank-line separation from `- First item:`, and then `- Second item` (back to `Dash`) was treated as yet another "new list" relative to the ordered sublist — producing 4 spurious violations.

## Fix

`src/lint/rules/md032.rs`: an indented list-marker line encountered while already inside a list is now always treated as a nested-list continuation (same as the existing handling for indented non-marker continuation lines) — its marker is never compared against the enclosing list, and it never mutates the enclosing list's tracked marker/state. Sibling lists at the *same* indentation with different markers (e.g. `* a` immediately followed by `+ b`) are unaffected and still correctly flagged (`test_mixed_markers_are_separate_lists` still passes).

Also fixed, discovered while verifying via `prek run -a` → `cargo test`: `glob::walker::tests::test_gitignore_respect` spawns `git init` in a temp dir but didn't clear `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`. When `cargo test` runs under this repo's own pre-commit hook (as `prek` does), git sets those for the *outer* repo and the child `git init` inherits them, silently reusing the outer repo instead of creating a fresh one in the temp dir — so the test's `.gitignore` was never actually applied and the assertion flaked. This is unrelated to #67 but blocked committing through the hook at all, so it's included as a separate commit.

## Test plan

- `src/lint/rules/md032.rs`: added `test_nested_list_different_marker_tight_not_flagged` and `test_nested_list_different_marker_loose_not_flagged` (0 violations for both the tight and blank-line-separated forms of the issue's repro). MD032 is not fixable, so no apply-fixes test per the project's testing strategy.
- `tests/formatter.rs`: added `nested_ordered_list_under_bullet_item_stays_tight`, locking in the formatter's existing (unchanged) canonical tight-nested-list output via `assert_formats_to` (covers both the format-matches-expected and idempotency assertions).
- `tests/integration.rs`: added `format_output_for_nested_list_passes_check`, a cross-subsystem check mirroring `check_clean_file_has_no_violations` — formats the issue's exact input and asserts `mdlint check` (all rules enabled) reports zero violations on the result.
- `cargo test`: 467 lib tests + all integration suites pass.
- `prek run -a`: passes clean (trailing-whitespace, actionlint, hadolint, tombi, clippy `-D warnings`, rustfmt, cargo test, mdlint dogfood format/check).
- Manually reproduced the issue's exact repro end-to-end: `mdlint format --no-config` then `mdlint check --no-config` now reports "Checked 1 file(s), no errors found."

Closes #67