### PR TITLE
Fix MD036 firing on emphasis-like text inside fenced code blocks

### DIFF
--- a/src/glob/walker.rs
+++ b/src/glob/walker.rs
@@ -116,9 +116,15 @@ mod tests {
     fn test_gitignore_respect() {
         let temp_dir = TempDir::new().unwrap();
 
+        // Clear inherited GIT_* vars so `git init` targets the temp dir instead of
+        // silently reusing the outer repo when this test runs inside a git hook
+        // (e.g. via `prek`/`cargo test` invoked from a pre-commit hook).
         std::process::Command::new("git")
             .args(["init"])
             .current_dir(temp_dir.path())
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .output()
             .unwrap();
 

--- a/src/lint/rules/md036.rs
+++ b/src/lint/rules/md036.rs
@@ -26,10 +26,14 @@ impl Rule for MD036 {
 
         let mut violations = Vec::new();
         let lines = parser.lines();
+        let code_block_lines = parser.get_code_block_line_numbers();
 
         // Track if we're in emphasis on a line-by-line basis
         for (line_num, line) in lines.iter().enumerate() {
             let line_number = line_num + 1;
+            if code_block_lines.contains(&line_number) {
+                continue;
+            }
             let trimmed = line.trim();
 
             // Check if the line looks like emphasis-only content
@@ -142,5 +146,25 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         assert_eq!(violations.len(), 0); // Not emphasis-only line
+    }
+
+    #[test]
+    fn test_emphasis_outside_code_block_still_flags() {
+        let content = "*2026-05-12*\n\nSome content";
+        let parser = MarkdownParser::new(content);
+        let rule = MD036;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_emphasis_inside_fenced_code_block_not_flagged() {
+        let content = "# Example\n\n```text\n*2026-05-12*\n```\n";
+        let parser = MarkdownParser::new(content);
+        let rule = MD036;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0); // Emphasis-like text inside a fenced code block isn't a heading
     }
 }


### PR DESCRIPTION
## Summary

- MD036 ("Emphasis used instead of a heading") scans raw text lines via `is_emphasis_only_line()` but never checked whether a line sits inside a fenced code block, unlike sibling line-scanning rules (MD003, MD018, MD019, etc.). Emphasis-looking content inside a code block (e.g. `*2026-05-12*` inside a ```` ```text ```` fence) was being flagged as if it were a heading candidate.
- Fix reuses `MarkdownParser::get_code_block_line_numbers()` (already precomputed, O(1) to access) and skips lines it contains, matching the exact pattern used by `md003.rs`/`md018.rs`/`md019.rs`.
- Also included: an unrelated pre-existing flaky test fix (`test_gitignore_respect` in `src/glob/walker.rs`) discovered while verifying via `prek run -a`. The test's `git init` subprocess inherited `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` from the outer repo whenever `cargo test` ran inside a git hook (as `prek`'s pre-commit hook does), silently reusing the outer repo instead of creating a fresh one in the temp dir. This blocked committing through the hook at all, so it's included as a separate, isolated commit.

## Root cause

`src/lint/rules/md036.rs`'s `check()` iterates `parser.lines()` directly with no code-block exclusion, so any line that merely *looks* like `*text*`/`**text**` gets flagged regardless of context.

## Fix

`src/lint/rules/md036.rs`: fetch `parser.get_code_block_line_numbers()` once and `continue` past any line number it contains, before running `is_emphasis_only_line()`.

## Test plan

- `src/lint/rules/md036.rs`: added `test_emphasis_outside_code_block_still_flags` (unchanged detection behavior outside code blocks) and `test_emphasis_inside_fenced_code_block_not_flagged` (the issue's exact repro — no violation). MD036 is not fixable, so no apply-fixes test per the project's testing strategy.
- `cargo test --lib md036`: 6/6 pass.
- `prek run -a`: passes clean (trailing-whitespace, actionlint, hadolint, tombi, clippy `-D warnings`, rustfmt, cargo test, mdlint dogfood format/check).

Closes #66