### PR TITLE
Exclude front matter/comments from linting; support markdownlint- directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,19 @@ names = ["JavaScript", "TypeScript", "GitHub"]
 
 See [`mdlint.default.toml`](mdlint.default.toml) for every option with its default value.
 
+### Front matter and comments
+
+YAML/TOML front matter is excluded from every rule, since it isn't Markdown content. A front matter `title` field
+is treated as the document's primary top-level heading, so MD025 (multiple top-level headings) and MD041 (first
+line should be a top-level heading) are satisfied by it instead of requiring a `#` heading in the body.
+
+HTML comments (`<!-- ... -->`, including multi-line comments) are excluded from every rule except MD013 (line
+length), since line length is a property of the raw line rather than of Markdown semantics.
+
 ### Inline configuration
 
-Rules can be suppressed for specific lines using HTML comments:
+Rules can be suppressed for specific lines using HTML comments. Both `mdlint-` and `markdownlint-` prefixes are
+accepted as equivalent aliases, so existing `markdownlint`/`markdownlint-cli2` comments keep working unchanged:
 
 ```markdown
 <!-- mdlint-disable-next-line MD013 -->
@@ -282,12 +292,18 @@ This line may be longer than the configured limit.
 | --- | --- |
 | `<!-- mdlint-disable MD001 -->` | Disable rule from this line onward |
 | `<!-- mdlint-enable MD001 -->` | Re-enable rule from this line onward |
+| `<!-- mdlint-disable-line MD001 -->` | Disable rule for the current line only |
 | `<!-- mdlint-disable-next-line MD001 -->` | Disable rule for the next line only |
 | `<!-- mdlint-disable -->` | Disable all rules from this line onward |
 | `<!-- mdlint-enable -->` | Re-enable all rules |
+| `<!-- mdlint-capture -->` | Save the current enable/disable state |
+| `<!-- mdlint-restore -->` | Restore the most recently captured state |
 
-Multiple rules: `<!-- mdlint-disable MD001 MD013 -->` — space-separate rule codes. Set `no_inline_config = true`
-in `mdlint.toml` to ignore all inline comments project-wide.
+Multiple rules: `<!-- mdlint-disable MD001 MD013 -->` — space-separate rule codes. `disable`/`enable` with no rule
+codes applies to every rule; a rule-specific `enable` after a bare `disable` re-enables just that rule (e.g. `disable`
+then `enable MD013` means "all rules except MD013"). `capture`/`restore` nest like a stack, so a block of directives
+can be undone as a unit regardless of what state it started from. Set `no_inline_config = true` in `mdlint.toml` to
+ignore all inline comments project-wide.
 
 ## Exit Codes
 
@@ -325,7 +341,7 @@ mdlint's. `—` means the rule has no configurable parameters.
 | [MD022](https://github.com/DavidAnson/markdownlint/blob/main/doc/md022.md) | ✓ | — | — | Headings should be surrounded by blank lines | Required by many renderers for correct parsing; format inserts blank lines |
 | [MD023](https://github.com/DavidAnson/markdownlint/blob/main/doc/md023.md) | ✓ | — | — | Headings must start at the beginning of the line | Indented headings are treated as code or paragraphs in CommonMark |
 | [MD024](https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md) |  | `siblings_only: false` |  | Multiple headings with the same content | Config: `siblings_only` — set `true` to flag only duplicates within the same parent heading |
-| [MD025](https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md) |  | — | — | Multiple top-level headings in the same document | Disable for document fragments that intentionally lack a single top-level title |
+| [MD025](https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md) |  | — | — | Multiple top-level headings in the same document | Disable for document fragments that intentionally lack a single top-level title. A front matter `title` field counts as the first top-level heading |
 | [MD026](https://github.com/DavidAnson/markdownlint/blob/main/doc/md026.md) |  | `".,;:!?。，；：！？"` | `".,;:!。，；：！"` | Trailing punctuation in heading | Headings are labels, not sentences. mdlint additionally disallows `?`. Config: `punctuation` |
 | [MD027](https://github.com/DavidAnson/markdownlint/blob/main/doc/md027.md) | ✓ | — | — | Multiple spaces after blockquote symbol | `>  text` → `> text`; format normalises |
 | [MD028](https://github.com/DavidAnson/markdownlint/blob/main/doc/md028.md) |  | — | — | Blank line inside blockquote | Blank lines split blockquotes into separate elements in CommonMark; may be intentional |
@@ -341,7 +357,7 @@ mdlint's. `—` means the rule has no configurable parameters.
 | [MD038](https://github.com/DavidAnson/markdownlint/blob/main/doc/md038.md) |  | — | — | Spaces inside code span elements | `` ` text ` `` is technically valid but inconsistent with expected style |
 | [MD039](https://github.com/DavidAnson/markdownlint/blob/main/doc/md039.md) |  | — | — | Spaces inside link text | `[ text ]` is valid but inconsistent |
 | [MD040](https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md) |  | — | — | Fenced code blocks should have a language specified | Language tags enable syntax highlighting. Config: `allowed_languages` |
-| [MD041](https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md) |  | `level: 1` |  | First line in file should be a top-level heading | Disable for files starting with badges, front matter, or that are document fragments |
+| [MD041](https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md) |  | `level: 1` |  | First line in file should be a top-level heading | Disable for files starting with badges or that are document fragments. A front matter `title` field satisfies this rule |
 | [MD042](https://github.com/DavidAnson/markdownlint/blob/main/doc/md042.md) |  | — | — | No empty links | `[text]()` is almost always a mistake |
 | [MD043](https://github.com/DavidAnson/markdownlint/blob/main/doc/md043.md) |  | — | — | Required heading structure | Useful for template-driven documentation; too restrictive for most projects. Config: `headings` |
 | [MD044](https://github.com/DavidAnson/markdownlint/blob/main/doc/md044.md) |  | `names: []` |  | Proper names should have the correct capitalization | Requires configuration to be useful. Config: `names`, `code_blocks` |

--- a/npm/README.md
+++ b/npm/README.md
@@ -265,9 +265,19 @@ names = ["JavaScript", "TypeScript", "GitHub"]
 
 See [`mdlint.default.toml`](mdlint.default.toml) for every option with its default value.
 
+### Front matter and comments
+
+YAML/TOML front matter is excluded from every rule, since it isn't Markdown content. A front matter `title` field
+is treated as the document's primary top-level heading, so MD025 (multiple top-level headings) and MD041 (first
+line should be a top-level heading) are satisfied by it instead of requiring a `#` heading in the body.
+
+HTML comments (`<!-- ... -->`, including multi-line comments) are excluded from every rule except MD013 (line
+length), since line length is a property of the raw line rather than of Markdown semantics.
+
 ### Inline configuration
 
-Rules can be suppressed for specific lines using HTML comments:
+Rules can be suppressed for specific lines using HTML comments. Both `mdlint-` and `markdownlint-` prefixes are
+accepted as equivalent aliases, so existing `markdownlint`/`markdownlint-cli2` comments keep working unchanged:
 
 ```markdown
 <!-- mdlint-disable-next-line MD013 -->
@@ -282,12 +292,18 @@ This line may be longer than the configured limit.
 | --- | --- |
 | `<!-- mdlint-disable MD001 -->` | Disable rule from this line onward |
 | `<!-- mdlint-enable MD001 -->` | Re-enable rule from this line onward |
+| `<!-- mdlint-disable-line MD001 -->` | Disable rule for the current line only |
 | `<!-- mdlint-disable-next-line MD001 -->` | Disable rule for the next line only |
 | `<!-- mdlint-disable -->` | Disable all rules from this line onward |
 | `<!-- mdlint-enable -->` | Re-enable all rules |
+| `<!-- mdlint-capture -->` | Save the current enable/disable state |
+| `<!-- mdlint-restore -->` | Restore the most recently captured state |
 
-Multiple rules: `<!-- mdlint-disable MD001 MD013 -->` — space-separate rule codes. Set `no_inline_config = true`
-in `mdlint.toml` to ignore all inline comments project-wide.
+Multiple rules: `<!-- mdlint-disable MD001 MD013 -->` — space-separate rule codes. `disable`/`enable` with no rule
+codes applies to every rule; a rule-specific `enable` after a bare `disable` re-enables just that rule (e.g. `disable`
+then `enable MD013` means "all rules except MD013"). `capture`/`restore` nest like a stack, so a block of directives
+can be undone as a unit regardless of what state it started from. Set `no_inline_config = true` in `mdlint.toml` to
+ignore all inline comments project-wide.
 
 ## Exit Codes
 
@@ -325,7 +341,7 @@ mdlint's. `—` means the rule has no configurable parameters.
 | [MD022](https://github.com/DavidAnson/markdownlint/blob/main/doc/md022.md) | ✓ | — | — | Headings should be surrounded by blank lines | Required by many renderers for correct parsing; format inserts blank lines |
 | [MD023](https://github.com/DavidAnson/markdownlint/blob/main/doc/md023.md) | ✓ | — | — | Headings must start at the beginning of the line | Indented headings are treated as code or paragraphs in CommonMark |
 | [MD024](https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md) |  | `siblings_only: false` |  | Multiple headings with the same content | Config: `siblings_only` — set `true` to flag only duplicates within the same parent heading |
-| [MD025](https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md) |  | — | — | Multiple top-level headings in the same document | Disable for document fragments that intentionally lack a single top-level title |
+| [MD025](https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md) |  | — | — | Multiple top-level headings in the same document | Disable for document fragments that intentionally lack a single top-level title. A front matter `title` field counts as the first top-level heading |
 | [MD026](https://github.com/DavidAnson/markdownlint/blob/main/doc/md026.md) |  | `".,;:!?。，；：！？"` | `".,;:!。，；：！"` | Trailing punctuation in heading | Headings are labels, not sentences. mdlint additionally disallows `?`. Config: `punctuation` |
 | [MD027](https://github.com/DavidAnson/markdownlint/blob/main/doc/md027.md) | ✓ | — | — | Multiple spaces after blockquote symbol | `>  text` → `> text`; format normalises |
 | [MD028](https://github.com/DavidAnson/markdownlint/blob/main/doc/md028.md) |  | — | — | Blank line inside blockquote | Blank lines split blockquotes into separate elements in CommonMark; may be intentional |
@@ -341,7 +357,7 @@ mdlint's. `—` means the rule has no configurable parameters.
 | [MD038](https://github.com/DavidAnson/markdownlint/blob/main/doc/md038.md) |  | — | — | Spaces inside code span elements | `` ` text ` `` is technically valid but inconsistent with expected style |
 | [MD039](https://github.com/DavidAnson/markdownlint/blob/main/doc/md039.md) |  | — | — | Spaces inside link text | `[ text ]` is valid but inconsistent |
 | [MD040](https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md) |  | — | — | Fenced code blocks should have a language specified | Language tags enable syntax highlighting. Config: `allowed_languages` |
-| [MD041](https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md) |  | `level: 1` |  | First line in file should be a top-level heading | Disable for files starting with badges, front matter, or that are document fragments |
+| [MD041](https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md) |  | `level: 1` |  | First line in file should be a top-level heading | Disable for files starting with badges or that are document fragments. A front matter `title` field satisfies this rule |
 | [MD042](https://github.com/DavidAnson/markdownlint/blob/main/doc/md042.md) |  | — | — | No empty links | `[text]()` is almost always a mistake |
 | [MD043](https://github.com/DavidAnson/markdownlint/blob/main/doc/md043.md) |  | — | — | Required heading structure | Useful for template-driven documentation; too restrictive for most projects. Config: `headings` |
 | [MD044](https://github.com/DavidAnson/markdownlint/blob/main/doc/md044.md) |  | `names: []` |  | Proper names should have the correct capitalization | Requires configuration to be useful. Config: `names`, `code_blocks` |

--- a/python/README.md
+++ b/python/README.md
@@ -265,9 +265,19 @@ names = ["JavaScript", "TypeScript", "GitHub"]
 
 See [`mdlint.default.toml`](mdlint.default.toml) for every option with its default value.
 
+### Front matter and comments
+
+YAML/TOML front matter is excluded from every rule, since it isn't Markdown content. A front matter `title` field
+is treated as the document's primary top-level heading, so MD025 (multiple top-level headings) and MD041 (first
+line should be a top-level heading) are satisfied by it instead of requiring a `#` heading in the body.
+
+HTML comments (`<!-- ... -->`, including multi-line comments) are excluded from every rule except MD013 (line
+length), since line length is a property of the raw line rather than of Markdown semantics.
+
 ### Inline configuration
 
-Rules can be suppressed for specific lines using HTML comments:
+Rules can be suppressed for specific lines using HTML comments. Both `mdlint-` and `markdownlint-` prefixes are
+accepted as equivalent aliases, so existing `markdownlint`/`markdownlint-cli2` comments keep working unchanged:
 
 ```markdown
 <!-- mdlint-disable-next-line MD013 -->
@@ -282,12 +292,18 @@ This line may be longer than the configured limit.
 | --- | --- |
 | `<!-- mdlint-disable MD001 -->` | Disable rule from this line onward |
 | `<!-- mdlint-enable MD001 -->` | Re-enable rule from this line onward |
+| `<!-- mdlint-disable-line MD001 -->` | Disable rule for the current line only |
 | `<!-- mdlint-disable-next-line MD001 -->` | Disable rule for the next line only |
 | `<!-- mdlint-disable -->` | Disable all rules from this line onward |
 | `<!-- mdlint-enable -->` | Re-enable all rules |
+| `<!-- mdlint-capture -->` | Save the current enable/disable state |
+| `<!-- mdlint-restore -->` | Restore the most recently captured state |
 
-Multiple rules: `<!-- mdlint-disable MD001 MD013 -->` — space-separate rule codes. Set `no_inline_config = true`
-in `mdlint.toml` to ignore all inline comments project-wide.
+Multiple rules: `<!-- mdlint-disable MD001 MD013 -->` — space-separate rule codes. `disable`/`enable` with no rule
+codes applies to every rule; a rule-specific `enable` after a bare `disable` re-enables just that rule (e.g. `disable`
+then `enable MD013` means "all rules except MD013"). `capture`/`restore` nest like a stack, so a block of directives
+can be undone as a unit regardless of what state it started from. Set `no_inline_config = true` in `mdlint.toml` to
+ignore all inline comments project-wide.
 
 ## Exit Codes
 
@@ -325,7 +341,7 @@ mdlint's. `—` means the rule has no configurable parameters.
 | [MD022](https://github.com/DavidAnson/markdownlint/blob/main/doc/md022.md) | ✓ | — | — | Headings should be surrounded by blank lines | Required by many renderers for correct parsing; format inserts blank lines |
 | [MD023](https://github.com/DavidAnson/markdownlint/blob/main/doc/md023.md) | ✓ | — | — | Headings must start at the beginning of the line | Indented headings are treated as code or paragraphs in CommonMark |
 | [MD024](https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md) |  | `siblings_only: false` |  | Multiple headings with the same content | Config: `siblings_only` — set `true` to flag only duplicates within the same parent heading |
-| [MD025](https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md) |  | — | — | Multiple top-level headings in the same document | Disable for document fragments that intentionally lack a single top-level title |
+| [MD025](https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md) |  | — | — | Multiple top-level headings in the same document | Disable for document fragments that intentionally lack a single top-level title. A front matter `title` field counts as the first top-level heading |
 | [MD026](https://github.com/DavidAnson/markdownlint/blob/main/doc/md026.md) |  | `".,;:!?。，；：！？"` | `".,;:!。，；：！"` | Trailing punctuation in heading | Headings are labels, not sentences. mdlint additionally disallows `?`. Config: `punctuation` |
 | [MD027](https://github.com/DavidAnson/markdownlint/blob/main/doc/md027.md) | ✓ | — | — | Multiple spaces after blockquote symbol | `>  text` → `> text`; format normalises |
 | [MD028](https://github.com/DavidAnson/markdownlint/blob/main/doc/md028.md) |  | — | — | Blank line inside blockquote | Blank lines split blockquotes into separate elements in CommonMark; may be intentional |
@@ -341,7 +357,7 @@ mdlint's. `—` means the rule has no configurable parameters.
 | [MD038](https://github.com/DavidAnson/markdownlint/blob/main/doc/md038.md) |  | — | — | Spaces inside code span elements | `` ` text ` `` is technically valid but inconsistent with expected style |
 | [MD039](https://github.com/DavidAnson/markdownlint/blob/main/doc/md039.md) |  | — | — | Spaces inside link text | `[ text ]` is valid but inconsistent |
 | [MD040](https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md) |  | — | — | Fenced code blocks should have a language specified | Language tags enable syntax highlighting. Config: `allowed_languages` |
-| [MD041](https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md) |  | `level: 1` |  | First line in file should be a top-level heading | Disable for files starting with badges, front matter, or that are document fragments |
+| [MD041](https://github.com/DavidAnson/markdownlint/blob/main/doc/md041.md) |  | `level: 1` |  | First line in file should be a top-level heading | Disable for files starting with badges or that are document fragments. A front matter `title` field satisfies this rule |
 | [MD042](https://github.com/DavidAnson/markdownlint/blob/main/doc/md042.md) |  | — | — | No empty links | `[text]()` is almost always a mistake |
 | [MD043](https://github.com/DavidAnson/markdownlint/blob/main/doc/md043.md) |  | — | — | Required heading structure | Useful for template-driven documentation; too restrictive for most projects. Config: `headings` |
 | [MD044](https://github.com/DavidAnson/markdownlint/blob/main/doc/md044.md) |  | `names: []` |  | Proper names should have the correct capitalization | Requires configuration to be useful. Config: `names`, `code_blocks` |

--- a/src/lint/engine.rs
+++ b/src/lint/engine.rs
@@ -27,8 +27,22 @@ impl LintEngine {
             .flat_map(|rule| self.violations(&parser, rule))
             .collect();
 
+        // Front matter is not markdown content: exclude it from every rule (MD025
+        // instead treats its `title` field as the document's first heading).
+        // Comments are excluded from every rule except MD013, since line length
+        // is a mechanical property of the raw line, not a markdown-semantics one.
+        violations.retain(|v| {
+            !parser.front_matter_lines().contains(&v.line)
+                && (v.rule == "MD013" || !parser.comment_lines().contains(&v.line))
+        });
+
         if !self.config.no_inline_config {
-            let suppressed = parse_inline_config(content);
+            let all_rule_names: Vec<String> = self
+                .registry
+                .all_rules()
+                .map(|rule| rule.name().to_owned())
+                .collect();
+            let suppressed = parse_inline_config(content, &all_rule_names);
             if !suppressed.is_empty() {
                 violations.retain(|v| {
                     let line = v.line;
@@ -82,101 +96,161 @@ impl LintEngine {
 
 /// Parse inline configuration comments from document content.
 ///
+/// Both `mdlint-` and `markdownlint-` prefixes are accepted as equivalent aliases.
 /// Supports:
 /// - `<!-- mdlint-disable -->` / `<!-- mdlint-disable MD001 MD003 -->`
 /// - `<!-- mdlint-enable -->` / `<!-- mdlint-enable MD001 -->`
+/// - `<!-- mdlint-disable-line -->` / `<!-- mdlint-disable-line MD001 -->`
 /// - `<!-- mdlint-disable-next-line -->` / `<!-- mdlint-disable-next-line MD001 -->`
+/// - `<!-- mdlint-capture -->` / `<!-- mdlint-restore -->` — push/pop the current
+///   disable/enable state, so a block of directives can be undone as a unit.
 ///
-/// Returns a map from rule name (or `"*"` for all rules) to the set of suppressed line numbers.
-fn parse_inline_config(content: &str) -> HashMap<String, HashSet<usize>> {
-    let lines: Vec<&str> = content.lines().collect();
-    let total_lines = lines.len();
+/// Returns a map from rule name to the set of suppressed line numbers.
+fn parse_inline_config(
+    content: &str,
+    all_rule_names: &[String],
+) -> HashMap<String, HashSet<usize>> {
+    // `default_disabled` is the state set by a bare disable/enable (applies to
+    // every rule); `overrides` holds rule-specific exceptions layered on top of
+    // it, so `disable` followed by `enable MD013` means "all rules except MD013".
+    let mut default_disabled = false;
+    let mut overrides: HashMap<String, bool> = HashMap::new();
+    let mut capture_stack: Vec<(bool, HashMap<String, bool>)> = Vec::new();
+    let mut pending_next_line: Option<Vec<String>> = None;
 
-    // Active disable ranges awaiting a matching enable: rule -> start line
-    let mut active: HashMap<String, usize> = HashMap::new();
-    // Completed ranges: rule -> [(start, end)]
-    let mut ranges: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
-
-    for (idx, line) in lines.iter().enumerate() {
-        let line_num = idx + 1;
-        let Some((kind, rule_names)) = extract_directive(line) else {
-            continue;
-        };
-        match kind {
-            DirectiveKind::DisableNextLine => {
-                let next = line_num + 1;
-                for rule in rules_or_all(rule_names) {
-                    ranges.entry(rule).or_default().push((next, next));
-                }
-            }
-            DirectiveKind::Disable => {
-                for rule in rules_or_all(rule_names) {
-                    active.entry(rule).or_insert(line_num);
-                }
-            }
-            DirectiveKind::Enable => {
-                let to_enable = rules_or_all(rule_names);
-                if to_enable.contains(&"*".to_owned()) {
-                    for (rule, start) in active.drain() {
-                        ranges.entry(rule).or_default().push((start, line_num - 1));
-                    }
-                } else {
-                    for rule in to_enable {
-                        if let Some(start) = active.remove(&rule) {
-                            ranges.entry(rule).or_default().push((start, line_num - 1));
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // Close any remaining open disables at end of document
-    for (rule, start) in active {
-        ranges.entry(rule).or_default().push((start, total_lines));
-    }
-
-    // Expand ranges into per-line sets
     let mut suppressed: HashMap<String, HashSet<usize>> = HashMap::new();
-    for (rule, rule_ranges) in ranges {
-        let entry = suppressed.entry(rule).or_default();
-        for (start, end) in rule_ranges {
-            entry.extend(start..=end);
+
+    for (idx, line) in content.lines().enumerate() {
+        let line_num = idx + 1;
+        let mut disable_line_rules: Vec<String> = Vec::new();
+
+        // A disable-next-line directive on the *previous* line applies here.
+        if let Some(rules) = pending_next_line.take() {
+            for rule in rules {
+                suppressed.entry(rule).or_default().insert(line_num);
+            }
+        }
+
+        for (kind, rule_names) in extract_directives(line) {
+            match kind {
+                DirectiveKind::Disable => {
+                    if rule_names.is_empty() {
+                        default_disabled = true;
+                        overrides.clear();
+                    } else {
+                        overrides.extend(rule_names.into_iter().map(|r| (r, true)));
+                    }
+                }
+                DirectiveKind::Enable => {
+                    if rule_names.is_empty() {
+                        default_disabled = false;
+                        overrides.clear();
+                    } else {
+                        overrides.extend(rule_names.into_iter().map(|r| (r, false)));
+                    }
+                }
+                DirectiveKind::DisableLine => {
+                    disable_line_rules.extend(rules_or_all(rule_names, all_rule_names));
+                }
+                DirectiveKind::DisableNextLine => {
+                    pending_next_line = Some(rules_or_all(rule_names, all_rule_names));
+                }
+                DirectiveKind::Capture => {
+                    capture_stack.push((default_disabled, overrides.clone()));
+                }
+                DirectiveKind::Restore => {
+                    if let Some((d, o)) = capture_stack.pop() {
+                        default_disabled = d;
+                        overrides = o;
+                    }
+                }
+            }
+        }
+
+        // Block-level suppression: the state as of *this* line (i.e. including any
+        // disable/enable directive on this line) applies to this line, matching
+        // markdownlint semantics where a disable comment suppresses its own line
+        // and a matching enable comment does not.
+        if default_disabled || !overrides.is_empty() {
+            for rule in all_rule_names {
+                let disabled = *overrides.get(rule).unwrap_or(&default_disabled);
+                if disabled {
+                    suppressed.entry(rule.clone()).or_default().insert(line_num);
+                }
+            }
+        }
+
+        for rule in disable_line_rules {
+            suppressed.entry(rule).or_default().insert(line_num);
         }
     }
+
     suppressed
 }
 
 enum DirectiveKind {
     Disable,
     Enable,
+    DisableLine,
     DisableNextLine,
+    Capture,
+    Restore,
 }
 
-/// Extract an mdlint directive from a line, returning the kind and the list of rule names
-/// (empty = apply to all rules). Returns `None` if the line contains no directive.
-fn extract_directive(line: &str) -> Option<(DirectiveKind, Vec<String>)> {
-    let start = line.find("<!--")?;
-    let end = line[start..].find("-->")?;
-    let body = line[start + 4..start + end].trim();
-
-    if let Some(rest) = body.strip_prefix("mdlint-disable-next-line") {
-        Some((DirectiveKind::DisableNextLine, parse_rule_names(rest)))
-    } else if let Some(rest) = body.strip_prefix("mdlint-disable") {
-        Some((DirectiveKind::Disable, parse_rule_names(rest)))
-    } else {
-        body.strip_prefix("mdlint-enable")
-            .map(|rest| (DirectiveKind::Enable, parse_rule_names(rest)))
+/// Extract every mdlint/markdownlint directive from a line. Usually a line has at
+/// most one, but each `<!-- ... -->` comment on the line is scanned independently.
+fn extract_directives(line: &str) -> Vec<(DirectiveKind, Vec<String>)> {
+    let mut directives = Vec::new();
+    let mut rest = line;
+    while let Some(start) = rest.find("<!--") {
+        let Some(end) = rest[start..].find("-->") else {
+            break;
+        };
+        let body = rest[start + 4..start + end].trim();
+        if let Some(directive) = parse_directive_body(body) {
+            directives.push(directive);
+        }
+        rest = &rest[start + end + 3..];
     }
+    directives
+}
+
+/// Parse a single comment body (already stripped of `<!--`/`-->`) into a directive
+/// kind and its rule-name arguments (empty = apply to all rules). Returns `None`
+/// if the body isn't a recognized directive.
+fn parse_directive_body(body: &str) -> Option<(DirectiveKind, Vec<String>)> {
+    let rest = body
+        .strip_prefix("markdownlint-")
+        .or_else(|| body.strip_prefix("mdlint-"))?;
+
+    // Longest-prefix-first so "disable-next-line"/"disable-line" aren't shadowed
+    // by the shorter "disable" prefix.
+    let (kind, rest) = if let Some(r) = rest.strip_prefix("disable-next-line") {
+        (DirectiveKind::DisableNextLine, r)
+    } else if let Some(r) = rest.strip_prefix("disable-line") {
+        (DirectiveKind::DisableLine, r)
+    } else if let Some(r) = rest.strip_prefix("disable") {
+        (DirectiveKind::Disable, r)
+    } else if let Some(r) = rest.strip_prefix("enable") {
+        (DirectiveKind::Enable, r)
+    } else if let Some(r) = rest.strip_prefix("capture") {
+        (DirectiveKind::Capture, r)
+    } else if let Some(r) = rest.strip_prefix("restore") {
+        (DirectiveKind::Restore, r)
+    } else {
+        return None;
+    };
+
+    Some((kind, parse_rule_names(rest)))
 }
 
 fn parse_rule_names(s: &str) -> Vec<String> {
     s.split_whitespace().map(str::to_owned).collect()
 }
 
-fn rules_or_all(rules: Vec<String>) -> Vec<String> {
+fn rules_or_all(rules: Vec<String>, all_rule_names: &[String]) -> Vec<String> {
     if rules.is_empty() {
-        vec!["*".to_owned()]
+        all_rule_names.to_vec()
     } else {
         rules
     }
@@ -283,12 +357,133 @@ mod tests {
 
     #[test]
     fn test_disable_without_enable_suppresses_to_end() {
-        let content = "# Heading\n\n<!-- mdlint-disable MD013 -->\nA very long line that goes on and on and on and on and on and on and on and on and on and on and on and on and on\n";
+        let content = "# Heading\n\n<!-- mdlint-disable MD013 -->\nA very long line that goes on and on and on and on and on and on and on and on and on and on and on and on and on and on and on\n";
         let engine = engine_all_rules();
         let violations = engine.lint_content(content).unwrap();
         assert!(
             violations.iter().all(|v| v.rule != "MD013"),
             "MD013 should be suppressed to end of file: {violations:?}"
+        );
+    }
+
+    #[test]
+    fn test_markdownlint_prefix_alias_disable_next_line() {
+        let content = "<!-- markdownlint-disable-next-line MD018 -->\n#Heading without space\n";
+        let engine = engine_all_rules();
+        let violations = engine.lint_content(content).unwrap();
+        assert!(
+            violations.iter().all(|v| v.rule != "MD018"),
+            "markdownlint- prefix should behave like mdlint-: {violations:?}"
+        );
+    }
+
+    #[test]
+    fn test_markdownlint_prefix_alias_disable_enable() {
+        let content = "<!-- markdownlint-disable MD041 -->\nNo heading here\n<!-- markdownlint-enable MD041 -->\n";
+        let engine = engine_all_rules();
+        let violations = engine.lint_content(content).unwrap();
+        assert!(
+            violations.iter().all(|v| v.rule != "MD041"),
+            "markdownlint-disable/enable should behave like mdlint-: {violations:?}"
+        );
+    }
+
+    #[test]
+    fn test_disable_line_suppresses_only_current_line() {
+        let content = "#Bad heading <!-- mdlint-disable-line MD018 -->\n#Also bad heading\n";
+        let engine = engine_all_rules();
+        let violations = engine.lint_content(content).unwrap();
+        assert!(
+            violations
+                .iter()
+                .all(|v| !(v.rule == "MD018" && v.line == 1)),
+            "MD018 should be suppressed on line 1: {violations:?}"
+        );
+        assert!(
+            violations.iter().any(|v| v.rule == "MD018" && v.line == 2),
+            "MD018 on line 2 should still fire: {violations:?}"
+        );
+    }
+
+    #[test]
+    fn test_disable_then_enable_specific_rule_means_all_except() {
+        // "disable" (bare) then "enable MD013" should leave everything else
+        // disabled but MD013 checked.
+        let content = "<!-- mdlint-disable -->\n<!-- mdlint-enable MD013 -->\n#Bad heading\nA very long line that goes on and on and on and on and on and on and on and on and on and on and on and on and on and on and on\n";
+        let engine = engine_all_rules();
+        let violations = engine.lint_content(content).unwrap();
+        assert!(
+            violations.iter().all(|v| v.rule != "MD018"),
+            "MD018 should stay suppressed under the blanket disable: {violations:?}"
+        );
+        assert!(
+            violations.iter().any(|v| v.rule == "MD013"),
+            "MD013 should be checked again after being explicitly enabled: {violations:?}"
+        );
+    }
+
+    #[test]
+    fn test_capture_restore_roundtrip() {
+        // capture saves the (enabled) state; a disable inside the captured scope
+        // is undone by restore, so MD013 fires again afterward.
+        let content = "<!-- mdlint-capture -->\n<!-- mdlint-disable MD013 -->\n<!-- mdlint-restore -->\nA very long line that goes on and on and on and on and on and on and on and on and on and on and on and on and on and on and on\n";
+        let engine = engine_all_rules();
+        let violations = engine.lint_content(content).unwrap();
+        assert!(
+            violations.iter().any(|v| v.rule == "MD013"),
+            "MD013 should fire again after restore undoes the nested disable: {violations:?}"
+        );
+    }
+
+    #[test]
+    fn test_disable_persists_through_restore_when_captured_while_disabled() {
+        // capture saves the (disabled) state; a nested disable of the same rule
+        // is a no-op, so MD013 stays suppressed after restore too.
+        let content = "<!-- mdlint-disable MD013 -->\n<!-- mdlint-capture -->\n<!-- mdlint-disable MD013 -->\n<!-- mdlint-restore -->\nA very long line that goes on and on and on and on and on and on and on and on and on and on and on and on and on and on and on\n";
+        let engine = engine_all_rules();
+        let violations = engine.lint_content(content).unwrap();
+        assert!(
+            violations.iter().all(|v| v.rule != "MD013"),
+            "MD013 should remain suppressed: {violations:?}"
+        );
+    }
+
+    #[test]
+    fn test_restore_without_capture_is_a_no_op() {
+        let content = "<!-- mdlint-restore -->\n#Bad heading\n";
+        let engine = engine_all_rules();
+        // Should not panic and should behave as if no directive was present.
+        let violations = engine.lint_content(content).unwrap();
+        assert!(violations.iter().any(|v| v.rule == "MD018"));
+    }
+
+    /// Acceptance test for GitHub issue #51: front matter and HTML comments
+    /// should be excluded from checking (except MD013, which still measures raw
+    /// line length), a front matter `title` should count as the document's first
+    /// top-level heading for MD025, and both `mdlint-` and `markdownlint-`
+    /// prefixed inline directives should be recognized. This is the exact
+    /// `test.md` from the issue; the exact violation set below is the issue's
+    /// own "Expected output".
+    #[test]
+    fn test_issue_51_acceptance() {
+        let content = "---\ntitle: Metadata should not be handled as markdown\ntags:\n    - a\n    - b\nreference: http://example.com/as/bare/url\n---\n<!--\nComments should be ignored.\n\nReferences: http://example.com/as/bare/url\n-->\n\n<!-- (a) ignore comments during checking and linting -->\n<!-- (b) MD025 should pay attention to the metadata (title) and should report \"Multiple top-level headings in the same document\" -->\n# Test Markdown File\n\nSupport for temporary enable and disable rules via:\n<!-- markdownlint-disable MD0XX MD0XY -->\nand maybe also\n<!-- mdlint-disable MD0XX MD0XY -->\nsimilar to <https://github.com/DavidAnson/markdownlint#configuration>.\nAn example would be:\n\n<!-- markdownlint-disable-next-line MD025 -->\n# Another but this time valid top-level header\n";
+        let engine = engine_all_rules();
+        let violations = engine.lint_content(content).unwrap();
+
+        assert_eq!(
+            violations.len(),
+            2,
+            "expected exactly MD013@15 and MD025@16: {violations:?}"
+        );
+        assert!(
+            violations.iter().any(|v| v.rule == "MD013" && v.line == 15),
+            "expected MD013 on line 15 (the over-long comment): {violations:?}"
+        );
+        assert!(
+            violations.iter().any(|v| v.rule == "MD025"
+                && v.line == 16
+                && v.message.contains("first h1 at line 2")),
+            "expected MD025 on line 16 referencing the front matter title at line 2: {violations:?}"
         );
     }
 }

--- a/src/lint/rules/md022.rs
+++ b/src/lint/rules/md022.rs
@@ -35,31 +35,30 @@ impl Rule for MD022 {
         for &heading_line in &heading_lines {
             let line_idx = heading_line - 1;
 
-            // Check if there's a blank line before (skip if first line or after blank)
-            if line_idx > 0 {
-                let prev_line = lines.get(line_idx - 1).expect("line_idx > 0").trim();
-                if !prev_line.is_empty() {
-                    // Replace the heading line with "\n<heading>" — the embedded newline
-                    // causes the Fixer to produce a blank line before the heading.
-                    violations.push(Violation {
-                        line: heading_line,
-                        column: Some(1),
-                        rule: self.name().to_owned(),
-                        message: "Heading should be surrounded by blank lines (missing before)"
-                            .to_owned(),
-                        fix: Some(Fix {
-                            line_start: heading_line,
-                            line_end: heading_line,
-                            column_start: None,
-                            column_end: None,
-                            replacement: format!(
-                                "\n{}",
-                                lines.get(line_idx).expect("heading line is valid")
-                            ),
-                            description: "Add blank line before heading".to_owned(),
-                        }),
-                    });
-                }
+            // Check if there's a blank line before (skip if first line or after blank).
+            // Comment/front-matter lines count as blank: they carry no content of
+            // their own, so a heading right after one is still "surrounded".
+            if line_idx > 0 && !parser.is_blank_line(heading_line - 1) {
+                // Replace the heading line with "\n<heading>" — the embedded newline
+                // causes the Fixer to produce a blank line before the heading.
+                violations.push(Violation {
+                    line: heading_line,
+                    column: Some(1),
+                    rule: self.name().to_owned(),
+                    message: "Heading should be surrounded by blank lines (missing before)"
+                        .to_owned(),
+                    fix: Some(Fix {
+                        line_start: heading_line,
+                        line_end: heading_line,
+                        column_start: None,
+                        column_end: None,
+                        replacement: format!(
+                            "\n{}",
+                            lines.get(line_idx).expect("heading line is valid")
+                        ),
+                        description: "Add blank line before heading".to_owned(),
+                    }),
+                });
             }
 
             // Check if there's a blank line after (skip if last line)
@@ -69,7 +68,7 @@ impl Rule for MD022 {
                     .expect("line_idx + 1 < lines.len()")
                     .trim();
                 // Allow another heading right after (for closed headings or setext underlines)
-                if !next_line.is_empty()
+                if !parser.is_blank_line(heading_line + 1)
                     && !next_line.starts_with('#')
                     && !next_line
                         .chars()
@@ -183,5 +182,25 @@ mod tests {
         assert!(violations[0].message.contains("after"));
         let fixed = apply_fixes(content, &violations);
         assert_eq!(fixed, "# Heading\n\nContent\n");
+    }
+
+    #[test]
+    fn test_comment_before_heading_counts_as_blank() {
+        let content = "<!-- a comment -->\n# Heading\n\nContent";
+        let parser = MarkdownParser::new(content);
+        let rule = MD022;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_front_matter_before_heading_counts_as_blank() {
+        let content = "---\ntitle: t\n---\n# Heading\n\nContent";
+        let parser = MarkdownParser::new(content);
+        let rule = MD022;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
     }
 }

--- a/src/lint/rules/md025.rs
+++ b/src/lint/rules/md025.rs
@@ -21,7 +21,9 @@ impl Rule for MD025 {
 
     fn check(&self, parser: &MarkdownParser, _config: Option<&Value>) -> Vec<Violation> {
         let mut violations = Vec::new();
-        let mut first_h1_line: Option<usize> = None;
+        // A front matter `title` field stands in for the document's first
+        // top-level heading, per markdownlint's `front_matter_title` convention.
+        let mut first_h1_line: Option<usize> = parser.front_matter_title_line();
 
         for (event, range) in parser.parse_with_offsets() {
             if let Event::Start(Tag::Heading {
@@ -30,6 +32,9 @@ impl Rule for MD025 {
             }) = event
             {
                 let line = parser.offset_to_line(range.start);
+                if parser.front_matter_lines().contains(&line) {
+                    continue;
+                }
 
                 if let Some(first_line) = first_h1_line {
                     violations.push(Violation {
@@ -93,6 +98,28 @@ mod tests {
     #[test]
     fn test_no_h1() {
         let content = "## Section\n### Subsection";
+        let parser = MarkdownParser::new(content);
+        let rule = MD025;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_front_matter_title_counts_as_first_h1() {
+        let content = "---\ntitle: My Title\n---\n\n# Body Heading\n";
+        let parser = MarkdownParser::new(content);
+        let rule = MD025;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 5);
+        assert!(violations[0].message.contains("first h1 at line 2"));
+    }
+
+    #[test]
+    fn test_front_matter_without_title_does_not_seed_first_h1() {
+        let content = "---\nauthor: Someone\n---\n\n# Body Heading\n";
         let parser = MarkdownParser::new(content);
         let rule = MD025;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md031.rs
+++ b/src/lint/rules/md031.rs
@@ -53,26 +53,27 @@ impl Rule for MD031 {
             let line_idx = start_line - 1;
 
             // Check blank line before (skip if first line)
-            if line_idx > 0 {
-                let prev_line = lines.get(line_idx - 1).expect("line_idx > 0").trim();
-                if !prev_line.is_empty() {
-                    // Insert blank line before code block
-                    violations.push(Violation {
-                        line: start_line,
-                        column: Some(1),
-                        rule: self.name().to_owned(),
-                        message:
-                            "Fenced code blocks should be surrounded by blank lines (missing before)".to_owned(),
-                        fix: Some(Fix {
-                            line_start: start_line,
-                            line_end: start_line,
-                            column_start: None,
-                            column_end: None,
-                            replacement: format!("\n{}", lines.get(line_idx).expect("line_idx bounded")),
-                            description: "Add blank line before code block".to_owned(),
-                        }),
-                    });
-                }
+            if line_idx > 0 && !parser.is_blank_line(start_line - 1) {
+                // Insert blank line before code block
+                violations.push(Violation {
+                    line: start_line,
+                    column: Some(1),
+                    rule: self.name().to_owned(),
+                    message:
+                        "Fenced code blocks should be surrounded by blank lines (missing before)"
+                            .to_owned(),
+                    fix: Some(Fix {
+                        line_start: start_line,
+                        line_end: start_line,
+                        column_start: None,
+                        column_end: None,
+                        replacement: format!(
+                            "\n{}",
+                            lines.get(line_idx).expect("line_idx bounded")
+                        ),
+                        description: "Add blank line before code block".to_owned(),
+                    }),
+                });
             }
         }
 
@@ -80,33 +81,27 @@ impl Rule for MD031 {
             let line_idx = end_line - 1;
 
             // Check blank line after (skip if last line)
-            if line_idx + 1 < lines.len() {
-                let next_line = lines
-                    .get(line_idx + 1)
-                    .expect("line_idx + 1 < lines.len()")
-                    .trim();
-                if !next_line.is_empty() {
-                    // Insert blank line after code block
-                    violations.push(Violation {
-                        line: end_line,
-                        column: Some(1),
-                        rule: self.name().to_owned(),
-                        message:
-                            "Fenced code blocks should be surrounded by blank lines (missing after)"
-                                .to_owned(),
-                        fix: Some(Fix {
-                            line_start: end_line,
-                            line_end: end_line,
-                            column_start: None,
-                            column_end: None,
-                            replacement: format!(
-                                "{}\n",
-                                lines.get(line_idx).expect("line_idx bounded")
-                            ),
-                            description: "Add blank line after code block".to_owned(),
-                        }),
-                    });
-                }
+            if line_idx + 1 < lines.len() && !parser.is_blank_line(end_line + 1) {
+                // Insert blank line after code block
+                violations.push(Violation {
+                    line: end_line,
+                    column: Some(1),
+                    rule: self.name().to_owned(),
+                    message:
+                        "Fenced code blocks should be surrounded by blank lines (missing after)"
+                            .to_owned(),
+                    fix: Some(Fix {
+                        line_start: end_line,
+                        line_end: end_line,
+                        column_start: None,
+                        column_end: None,
+                        replacement: format!(
+                            "{}\n",
+                            lines.get(line_idx).expect("line_idx bounded")
+                        ),
+                        description: "Add blank line after code block".to_owned(),
+                    }),
+                });
             }
         }
 
@@ -205,5 +200,15 @@ mod tests {
         // Verify blank lines were added
         let expected = "Text\n\n```\ncode\n```\n\nMore";
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_comment_around_code_block_counts_as_blank() {
+        let content = "<!-- note -->\n```\ncode\n```\n<!-- note -->\nMore";
+        let parser = MarkdownParser::new(content);
+        let rule = MD031;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
     }
 }

--- a/src/lint/rules/md032.rs
+++ b/src/lint/rules/md032.rs
@@ -61,35 +61,33 @@ impl Rule for MD032 {
                     current_marker = Some(marker);
                     last_list_line = line_num;
 
-                    // Check if previous line is blank (unless it's the first line)
-                    if line_num > 0 {
-                        let prev_line = lines.get(line_num - 1).expect("line_num > 0");
-                        if !prev_line.trim().is_empty() {
-                            // Detect broken ordered list continuation: a line that
-                            // looks like an ordered list item (e.g. "6.") following
-                            // non-list text won't be parsed as a list item because
-                            // only "1." can interrupt a paragraph (CommonMark §5.2).
-                            if marker == ListMarker::Ordered && !starts_with_one(trimmed) {
-                                // Report on the interrupting line (previous line),
-                                // not the list-like line — that's where the break is.
-                                violations.push(Violation {
-                                    line: line_num, // previous line (0-indexed → 1-indexed)
-                                    column: Some(1),
-                                    rule: self.name().to_owned(),
-                                    message: "Line breaks ordered list continuation; subsequent \
+                    // Check if previous line is blank (unless it's the first line).
+                    // Comment/front-matter lines count as blank here too.
+                    if line_num > 0 && !parser.is_blank_line(line_num) {
+                        // Detect broken ordered list continuation: a line that
+                        // looks like an ordered list item (e.g. "6.") following
+                        // non-list text won't be parsed as a list item because
+                        // only "1." can interrupt a paragraph (CommonMark §5.2).
+                        if marker == ListMarker::Ordered && !starts_with_one(trimmed) {
+                            // Report on the interrupting line (previous line),
+                            // not the list-like line — that's where the break is.
+                            violations.push(Violation {
+                                line: line_num, // previous line (0-indexed → 1-indexed)
+                                column: Some(1),
+                                rule: self.name().to_owned(),
+                                message: "Line breaks ordered list continuation; subsequent \
                                          numbered items are parsed as text, not list items"
-                                        .to_owned(),
-                                    fix: None,
-                                });
-                            } else {
-                                violations.push(Violation {
-                                    line: line_num + 1,
-                                    column: Some(1),
-                                    rule: self.name().to_owned(),
-                                    message: "List should be surrounded by blank lines".to_owned(),
-                                    fix: None,
-                                });
-                            }
+                                    .to_owned(),
+                                fix: None,
+                            });
+                        } else {
+                            violations.push(Violation {
+                                line: line_num + 1,
+                                column: Some(1),
+                                rule: self.name().to_owned(),
+                                message: "List should be surrounded by blank lines".to_owned(),
+                                fix: None,
+                            });
                         }
                     }
                 } else if Some(marker) != current_marker {
@@ -119,8 +117,9 @@ impl Rule for MD032 {
             } else if in_list && is_indented && !line.trim().is_empty() {
                 // Indented non-list line - this is a continuation of the list item
                 // Do nothing, stay in list
-            } else if in_list && !line.trim().is_empty() {
-                // Ending a list (non-blank, non-indented, non-list line)
+            } else if in_list && !parser.is_blank_line(line_num + 1) {
+                // Ending a list (non-blank, non-indented, non-list line). Comment
+                // and front-matter lines count as blank and don't end the list.
                 in_list = false;
                 current_marker = None;
 
@@ -132,7 +131,7 @@ impl Rule for MD032 {
                     message: "List should be surrounded by blank lines".to_owned(),
                     fix: None,
                 });
-            } else if in_list && line.trim().is_empty() {
+            } else if in_list && parser.is_blank_line(line_num + 1) {
                 // Blank line during list - might be end
                 // Look ahead to see if list continues with same marker
                 let mut continues = false;
@@ -324,6 +323,16 @@ mod tests {
         // list loose. Both forms are valid CommonMark and neither should be
         // flagged by MD032.
         let content = "# Example\n\n- First item:\n\n  1. One\n  2. Two\n\n- Second item\n";
+        let parser = MarkdownParser::new(content);
+        let rule = MD032;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_comment_around_list_counts_as_blank() {
+        let content = "<!-- note -->\n* Item 1\n* Item 2\n<!-- note -->\nText after";
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md041.rs
+++ b/src/lint/rules/md041.rs
@@ -21,6 +21,12 @@ impl Rule for MD041 {
 
     #[allow(clippy::cast_possible_truncation)] // serde_json gives u64; heading level is always ≤ 6
     fn check(&self, parser: &MarkdownParser, config: Option<&Value>) -> Vec<Violation> {
+        // A front matter `title` field stands in for the top-level heading,
+        // matching markdownlint's `front_matter_title` convention (see MD025).
+        if parser.front_matter_title().is_some() {
+            return Vec::new();
+        }
+
         let mut violations = Vec::new();
         let level = config
             .and_then(|c| c.get("level"))
@@ -71,7 +77,7 @@ impl Rule for MD041 {
                 {
                     // Non-heading content found first
                     violations.push(Violation {
-                        line: 1,
+                        line: parser.offset_to_line(range.start),
                         column: Some(1),
                         rule: self.name().to_owned(),
                         message: "First line in file should be a top-level heading".to_owned(),
@@ -133,5 +139,39 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         assert_eq!(violations.len(), 0); // Blank lines are OK
+    }
+
+    #[test]
+    fn test_reports_real_line_of_offending_content() {
+        // The violation should point at the actual first-content line, not a
+        // hardcoded line 1 — otherwise it can collide with unrelated content
+        // (e.g. an HTML comment) that happens to sit on line 1.
+        let content = "<!-- a comment -->\nSome text\n\n# Heading";
+        let parser = MarkdownParser::new(content);
+        let rule = MD041;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 2);
+    }
+
+    #[test]
+    fn test_front_matter_title_satisfies_rule() {
+        let content = "---\ntitle: My Title\n---\n\nContent with no heading";
+        let parser = MarkdownParser::new(content);
+        let rule = MD041;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_front_matter_without_title_still_checked() {
+        let content = "---\nauthor: Someone\n---\n\nContent with no heading";
+        let parser = MarkdownParser::new(content);
+        let rule = MD041;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 1);
     }
 }

--- a/src/markdown/front_matter.rs
+++ b/src/markdown/front_matter.rs
@@ -56,6 +56,31 @@ fn detect_filetype_front_matter(
     None
 }
 
+/// Extracts the `title` field from front matter content, returning its value and
+/// the 1-indexed line number it appears on in the original document. Front matter
+/// content starts at document line 2 (line 1 is the opening `---`/`+++` delimiter).
+#[must_use]
+pub fn extract_title(front_matter: &FrontMatter) -> Option<(String, usize)> {
+    let delimiter = match front_matter.matter_type {
+        FrontMatterType::Yaml => ':',
+        FrontMatterType::Toml => '=',
+    };
+    for (idx, line) in front_matter.content.lines().enumerate() {
+        let Some((key, value)) = line.split_once(delimiter) else {
+            continue;
+        };
+        let key = key.trim().trim_matches('"').trim_matches('\'');
+        if key != "title" {
+            continue;
+        }
+        let value = value.trim().trim_matches('"').trim_matches('\'');
+        if !value.is_empty() {
+            return Some((value.to_owned(), idx + 2));
+        }
+    }
+    None
+}
+
 #[allow(dead_code)]
 pub fn strip_front_matter(content: &str) -> String {
     if let Some(front_matter) = detect_front_matter(content) {
@@ -119,5 +144,43 @@ mod tests {
         let stripped = strip_front_matter(content);
 
         assert_eq!(stripped, content);
+    }
+
+    #[test]
+    fn test_extract_title_yaml() {
+        let content = "---\ntags:\n  - a\ntitle: My Title\n---\n# Heading";
+        let fm = detect_front_matter(content).unwrap();
+        let (title, line) = extract_title(&fm).unwrap();
+
+        assert_eq!(title, "My Title");
+        assert_eq!(line, 4);
+    }
+
+    #[test]
+    fn test_extract_title_toml() {
+        let content = "+++\nauthor = \"John\"\ntitle = \"My Title\"\n+++\n# Heading";
+        let fm = detect_front_matter(content).unwrap();
+        let (title, line) = extract_title(&fm).unwrap();
+
+        assert_eq!(title, "My Title");
+        assert_eq!(line, 3);
+    }
+
+    #[test]
+    fn test_extract_title_missing() {
+        let content = "---\nauthor: John\n---\n# Heading";
+        let fm = detect_front_matter(content).unwrap();
+
+        assert!(extract_title(&fm).is_none());
+    }
+
+    #[test]
+    fn test_extract_title_colon_in_value() {
+        let content = "---\ntitle: Something: Else\n---\n# Heading";
+        let fm = detect_front_matter(content).unwrap();
+        let (title, line) = extract_title(&fm).unwrap();
+
+        assert_eq!(title, "Something: Else");
+        assert_eq!(line, 2);
     }
 }

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1,5 +1,5 @@
 mod front_matter;
 mod parser;
 
-pub use front_matter::{FrontMatter, FrontMatterType, detect_front_matter};
+pub use front_matter::{FrontMatter, FrontMatterType, detect_front_matter, extract_title};
 pub use parser::MarkdownParser;

--- a/src/markdown/parser.rs
+++ b/src/markdown/parser.rs
@@ -1,3 +1,4 @@
+use crate::markdown::front_matter::{detect_front_matter, extract_title};
 use pulldown_cmark::{BrokenLink, CowStr, Event, Options, Parser, Tag, TagEnd};
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
@@ -18,6 +19,12 @@ pub struct MarkdownParser<'a> {
     ref_def_lines: HashSet<usize>,
     /// Map from normalised (lowercase) label to its 1-indexed line number.
     ref_defs: HashMap<String, usize>,
+    /// Lines (1-indexed) that are part of the YAML/TOML front matter block.
+    front_matter_lines: HashSet<usize>,
+    /// The front matter `title` field's value and 1-indexed line, if present.
+    front_matter_title: Option<(String, usize)>,
+    /// Lines (1-indexed) that fall entirely inside an HTML comment (`<!-- ... -->`).
+    comment_lines: HashSet<usize>,
 }
 
 impl<'a> MarkdownParser<'a> {
@@ -27,6 +34,13 @@ impl<'a> MarkdownParser<'a> {
         let line_offsets = build_line_offsets(content);
         let (code_block_lines, code_lines, code_ranges) = build_code_info(content, &line_offsets);
         let (ref_def_lines, ref_defs) = build_ref_def_info(content, &line_offsets);
+        let front_matter = detect_front_matter(content);
+        let front_matter_lines = front_matter
+            .as_ref()
+            .map(|fm| (1..=fm.end_line).collect())
+            .unwrap_or_default();
+        let front_matter_title = front_matter.as_ref().and_then(extract_title);
+        let comment_lines = build_comment_lines(content, &code_block_lines);
         Self {
             content,
             lines,
@@ -36,6 +50,9 @@ impl<'a> MarkdownParser<'a> {
             code_ranges,
             ref_def_lines,
             ref_defs,
+            front_matter_lines,
+            front_matter_title,
+            comment_lines,
         }
     }
 
@@ -140,6 +157,49 @@ impl<'a> MarkdownParser<'a> {
     #[must_use]
     pub fn get_ref_defs(&self) -> &HashMap<String, usize> {
         &self.ref_defs
+    }
+
+    /// Returns the 1-indexed line numbers that form the YAML/TOML front matter
+    /// block (including its `---`/`+++` delimiters). Result is precomputed in
+    /// `new()` — O(1) to access.
+    #[must_use]
+    pub fn front_matter_lines(&self) -> &HashSet<usize> {
+        &self.front_matter_lines
+    }
+
+    /// Returns the front matter `title` field's value, if present.
+    #[must_use]
+    pub fn front_matter_title(&self) -> Option<&str> {
+        self.front_matter_title
+            .as_ref()
+            .map(|(title, _)| title.as_str())
+    }
+
+    /// Returns the 1-indexed line number the front matter `title` field appears
+    /// on, if present.
+    #[must_use]
+    pub fn front_matter_title_line(&self) -> Option<usize> {
+        self.front_matter_title.as_ref().map(|(_, line)| *line)
+    }
+
+    /// Returns the 1-indexed line numbers that fall entirely inside an HTML
+    /// comment (`<!-- ... -->`). A line that has real content before the opening
+    /// `<!--` or after the closing `-->` is not included. Result is precomputed
+    /// in `new()` — O(1) to access.
+    #[must_use]
+    pub fn comment_lines(&self) -> &HashSet<usize> {
+        &self.comment_lines
+    }
+
+    /// Returns `true` if `line_num` is blank, or is entirely inside an HTML
+    /// comment or the front matter block — content that carries no linting
+    /// significance of its own but should not be treated as "missing" content
+    /// by rules that require blank-line separation (e.g. MD022, MD031, MD032).
+    #[must_use]
+    pub fn is_blank_line(&self, line_num: usize) -> bool {
+        self.get_line(line_num).is_none_or(|l| l.trim().is_empty())
+            || self.comment_lines.contains(&line_num)
+            || self.front_matter_lines.contains(&line_num)
     }
 
     /// Converts a (1-indexed) line number and 0-indexed byte offset within that
@@ -258,6 +318,56 @@ fn build_code_info(
     }
 
     (code_block_lines, code_lines, code_ranges)
+}
+
+/// Scans raw lines for HTML comments (`<!-- ... -->`, possibly spanning multiple
+/// lines) and returns the 1-indexed line numbers that fall *entirely* inside one —
+/// a line with real content before the opening `<!--` or after the closing `-->`
+/// is not included, so mixed lines like `text <!-- note -->` keep normal linting.
+/// Lines already inside a code block are skipped, since `<!--` inside a fence is
+/// literal text, not a comment.
+///
+/// AIDEV: raw-line scan, not tokenizer-accurate — a `<!--` inside an inline code
+/// span on a prose line is (incorrectly) treated as opening a comment. Upgrade to
+/// a code-range-aware scan if this proves to bite in practice.
+fn build_comment_lines(content: &str, code_block_lines: &HashSet<usize>) -> HashSet<usize> {
+    let mut comment_lines = HashSet::new();
+    let mut in_comment = false;
+
+    for (idx, line) in content.lines().enumerate() {
+        let line_num = idx + 1;
+        if code_block_lines.contains(&line_num) {
+            continue;
+        }
+
+        if in_comment {
+            if let Some(end) = line.find("-->") {
+                if line[end + 3..].trim().is_empty() {
+                    comment_lines.insert(line_num);
+                }
+                in_comment = false;
+            } else {
+                comment_lines.insert(line_num);
+            }
+            continue;
+        }
+
+        if let Some(start) = line.find("<!--") {
+            let before = line[..start].trim().is_empty();
+            if let Some(end) = line[start..].find("-->") {
+                if before && line[start + end + 3..].trim().is_empty() {
+                    comment_lines.insert(line_num);
+                }
+            } else {
+                if before {
+                    comment_lines.insert(line_num);
+                }
+                in_comment = true;
+            }
+        }
+    }
+
+    comment_lines
 }
 
 /// Collects link reference definition metadata in one pass over the parser's
@@ -479,5 +589,97 @@ mod tests {
         assert!(ref_def_lines.contains(&3), "ref def line should be marked");
         assert!(!ref_def_lines.contains(&1), "prose should not be marked");
         assert!(!ref_def_lines.contains(&5), "prose should not be marked");
+    }
+
+    #[test]
+    fn test_front_matter_lines() {
+        let content = "---\ntitle: Test\n---\n# Heading\nContent";
+        let parser = MarkdownParser::new(content);
+
+        assert_eq!(
+            parser.front_matter_lines(),
+            &HashSet::from([1, 2, 3]),
+            "front matter block (delimiters + content) should be marked"
+        );
+        assert!(!parser.front_matter_lines().contains(&4));
+    }
+
+    #[test]
+    fn test_front_matter_title() {
+        let content = "---\ntitle: My Title\n---\n# Heading";
+        let parser = MarkdownParser::new(content);
+
+        assert_eq!(parser.front_matter_title(), Some("My Title"));
+        assert_eq!(parser.front_matter_title_line(), Some(2));
+    }
+
+    #[test]
+    fn test_front_matter_title_absent() {
+        let content = "# Heading\nContent";
+        let parser = MarkdownParser::new(content);
+
+        assert_eq!(parser.front_matter_title(), None);
+        assert_eq!(parser.front_matter_title_line(), None);
+    }
+
+    #[test]
+    fn test_comment_lines_single_line() {
+        let content = "Text\n\n<!-- a comment -->\n\nMore text";
+        let parser = MarkdownParser::new(content);
+
+        assert!(parser.comment_lines().contains(&3));
+        assert!(!parser.comment_lines().contains(&1));
+        assert!(!parser.comment_lines().contains(&5));
+    }
+
+    #[test]
+    fn test_comment_lines_multi_line() {
+        let content = "Text\n<!--\nInside comment\nStill inside\n-->\nAfter";
+        let parser = MarkdownParser::new(content);
+
+        for line in 2..=5 {
+            assert!(
+                parser.comment_lines().contains(&line),
+                "line {line} should be inside the comment"
+            );
+        }
+        assert!(!parser.comment_lines().contains(&1));
+        assert!(!parser.comment_lines().contains(&6));
+    }
+
+    #[test]
+    fn test_comment_lines_mixed_content_not_marked() {
+        let content = "text before <!-- note --> text after";
+        let parser = MarkdownParser::new(content);
+
+        assert!(
+            !parser.comment_lines().contains(&1),
+            "a line with content outside the comment should not be marked"
+        );
+    }
+
+    #[test]
+    fn test_comment_lines_ignore_code_block() {
+        let content = "```\n<!-- not a comment, just text -->\n```";
+        let parser = MarkdownParser::new(content);
+
+        assert!(
+            parser.comment_lines().is_empty(),
+            "<!-- inside a fenced code block should not be treated as a comment"
+        );
+    }
+
+    #[test]
+    fn test_is_blank_line() {
+        let content = "---\ntitle: t\n---\nText\n\n<!-- comment -->\nMore";
+        let parser = MarkdownParser::new(content);
+
+        assert!(parser.is_blank_line(1), "front matter line should be blank");
+        assert!(parser.is_blank_line(5), "empty line should be blank");
+        assert!(
+            parser.is_blank_line(6),
+            "comment-only line should count as blank"
+        );
+        assert!(!parser.is_blank_line(4), "prose line should not be blank");
     }
 }


### PR DESCRIPTION
## Summary

- Front matter (YAML/TOML) is excluded from every lint rule, since it isn't Markdown content. A front matter `title` field is treated as the document's primary top-level heading, satisfying MD025 (multiple top-level headings) and MD041 (first line should be a heading) instead of requiring a body `#`.
- HTML comments (`<!-- ... -->`, including multi-line) are excluded from every rule except MD013, since line length is a mechanical property of the raw line rather than Markdown semantics.
- Inline directives now accept both `mdlint-` and `markdownlint-` prefixes as equivalent aliases, and add `disable-line` (current-line-only) and `capture`/`restore` (stack-based state save/restore) support, matching markdownlint's inline-comment configuration model. `disable` followed by a rule-specific `enable X` now correctly means "all rules except X".
- Fixed a latent MD041 bug along the way: it reported violations at a hardcoded `line: 1` instead of the actual offending line, which would have silently swallowed real violations under the new comment/front-matter exclusion filter.

Fixes #51.

## Test plan

- [x] New acceptance test (`test_issue_51_acceptance` in `src/lint/engine.rs`) reproduces the issue's exact `test.md` and asserts the exact expected output (`MD013` at line 15, `MD025` at line 16).
- [x] Manually ran `cargo run -- check --no-fix` against the issue's `test.md` and confirmed byte-for-byte match with the issue's "Expected output".
- [x] New unit tests for front matter/comment line tracking (`src/markdown/parser.rs`), MD025/MD041 front-matter-title handling, MD022/MD031/MD032 comment-as-blank-line handling, and the new directive syntax (`markdownlint-` alias, `disable-line`, `capture`/`restore`, `disable` + `enable X`).
- [x] Full test suite passes (`cargo test`).
- [x] `prek run -a` passes (clippy `-D warnings`, rustfmt, cargo test, mdlint self-dogfood).
- [x] `README.md`, `npm/README.md`, `python/README.md` updated in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)