### PR TITLE
Change test strings to be multiline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +523,7 @@ dependencies = [
  "clap",
  "globset",
  "ignore",
+ "indoc",
  "lsp-server",
  "lsp-types",
  "proptest",
@@ -753,6 +763,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ url = "^2.5.8"
 yaml_serde = "^0.10.4"
 
 [dev-dependencies]
+indoc = "^2.0.7"
 proptest = "^1.11.0"
 tempfile = "^3.27.0"
 

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -76,6 +76,7 @@ fn parse_toml_config(content: &str, _path: &Path) -> Result<Config> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
     use std::io::Write;
     use tempfile::TempDir;
 
@@ -106,13 +107,14 @@ style = "atx"
         let mut file = fs::File::create(&config_path).unwrap();
         write!(
             file,
-            "
-gitignore = true
-default_enabled = true
+            indoc! {"
 
-[rules.MD013]
-line_length = 80
-"
+                gitignore = true
+                default_enabled = true
+
+                [rules.MD013]
+                line_length = 80
+            "}
         )
         .unwrap();
 

--- a/src/fix/fixer.rs
+++ b/src/fix/fixer.rs
@@ -225,10 +225,14 @@ fn apply_single_fix(lines: &mut Vec<String>, fix: &Fix) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_detect_line_ending_lf() {
-        let content = "line1\nline2\nline3";
+        let content = indoc! {"
+            line1
+            line2
+            line3"};
         assert_eq!(detect_line_ending(content), "\n");
     }
 
@@ -240,7 +244,10 @@ mod tests {
 
     #[test]
     fn test_apply_single_line_fix() {
-        let content = "line 1\nline 2\nline 3";
+        let content = indoc! {"
+            line 1
+            line 2
+            line 3"};
         let fix = Fix {
             line_start: 2,
             line_end: 2,
@@ -252,7 +259,13 @@ mod tests {
 
         let fixer = Fixer::new();
         let result = fixer.apply_fixes_to_content(content, &[fix]).unwrap();
-        assert_eq!(result, "line 1\nREPLACED\nline 3");
+        assert_eq!(
+            result,
+            indoc! {"
+                line 1
+                REPLACED
+                line 3"}
+        );
     }
 
     #[test]
@@ -274,7 +287,10 @@ mod tests {
 
     #[test]
     fn test_multiple_fixes_reverse_order() {
-        let content = "line 1\nline 2\nline 3";
+        let content = indoc! {"
+            line 1
+            line 2
+            line 3"};
         let fixes = vec![
             Fix {
                 line_start: 1,
@@ -296,7 +312,13 @@ mod tests {
 
         let runner = Fixer::new();
         let result = runner.apply_fixes_to_content(content, &fixes).unwrap();
-        assert_eq!(result, "FIRST\nline 2\nTHIRD");
+        assert_eq!(
+            result,
+            indoc! {"
+                FIRST
+                line 2
+                THIRD"}
+        );
     }
 
     #[test]

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -819,6 +819,7 @@ fn needs_line_escape(line: &str, is_continuation: bool) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     /// Assert that `input` formats to `expected` AND that `expected` is already
     /// canonical (formatting it again produces no change — the "not-fix" side).
@@ -856,52 +857,119 @@ mod tests {
 
     #[test]
     fn test_heading_and_paragraph() {
-        let input = "# Title\n\nSome text.";
+        let input = indoc! {"
+            # Title
+
+            Some text."};
         let output = format(input);
-        assert_eq!(output, "# Title\n\nSome text.\n");
+        assert_eq!(
+            output,
+            indoc! {"
+                # Title
+
+                Some text.
+            "}
+        );
     }
 
     #[test]
     fn test_multiple_paragraphs() {
-        let input = "First paragraph.\n\nSecond paragraph.";
+        let input = indoc! {"
+            First paragraph.
+
+            Second paragraph."};
         let output = format(input);
-        assert_eq!(output, "First paragraph.\n\nSecond paragraph.\n");
+        assert_eq!(
+            output,
+            indoc! {"
+                First paragraph.
+
+                Second paragraph.
+            "}
+        );
     }
 
     #[test]
     fn test_fenced_code_block() {
-        let input = "```rust\nlet x = 1;\n```";
+        let input = indoc! {"
+            ```rust
+            let x = 1;
+            ```"};
         let output = format(input);
-        assert_eq!(output, "```rust\nlet x = 1;\n```\n");
+        assert_eq!(
+            output,
+            indoc! {"
+                ```rust
+                let x = 1;
+                ```
+            "}
+        );
     }
 
     #[test]
     fn test_code_block_no_lang() {
-        let input = "```\ncode here\n```";
+        let input = indoc! {"
+            ```
+            code here
+            ```"};
         let output = format(input);
-        assert_eq!(output, "```\ncode here\n```\n");
+        assert_eq!(
+            output,
+            indoc! {"
+                ```
+                code here
+                ```
+            "}
+        );
     }
 
     #[test]
     fn test_unordered_list() {
-        let input = "- Item 1\n- Item 2\n- Item 3";
+        let input = indoc! {"
+            - Item 1
+            - Item 2
+            - Item 3"};
         let output = format(input);
-        assert_eq!(output, "- Item 1\n- Item 2\n- Item 3\n");
+        assert_eq!(
+            output,
+            indoc! {"
+                - Item 1
+                - Item 2
+                - Item 3
+            "}
+        );
     }
 
     #[test]
     fn test_ordered_list() {
-        let input = "1. First\n2. Second\n3. Third";
+        let input = indoc! {"
+            1. First
+            2. Second
+            3. Third"};
         let output = format(input);
-        assert_eq!(output, "1. First\n2. Second\n3. Third\n");
+        assert_eq!(
+            output,
+            indoc! {"
+                1. First
+                2. Second
+                3. Third
+            "}
+        );
     }
 
     #[test]
     fn test_ordered_list_all_ones_renumbered() {
         // "one" style (1. / 1. / 1.) is canonicalized to sequential.
         assert_formats_to(
-            "1. First\n1. Second\n1. Third",
-            "1. First\n2. Second\n3. Third\n",
+            indoc! {"
+                1. First
+                1. Second
+                1. Third"},
+            indoc! {"
+                1. First
+                2. Second
+                3. Third
+            "},
         );
     }
 
@@ -909,8 +977,15 @@ mod tests {
     fn test_ordered_list_non_one_start_renumbered() {
         // Lists starting at a number other than 1 are renumbered from 1.
         assert_formats_to(
-            "3. First\n5. Second\n9. Third",
-            "1. First\n2. Second\n3. Third\n",
+            indoc! {"
+                3. First
+                5. Second
+                9. Third"},
+            indoc! {"
+                1. First
+                2. Second
+                3. Third
+            "},
         );
     }
 
@@ -940,23 +1015,57 @@ mod tests {
 
     #[test]
     fn test_blank_line_between_heading_and_code() {
-        let input = "# Heading\n\n```\ncode\n```";
+        let input = indoc! {"
+            # Heading
+
+            ```
+            code
+            ```"};
         let output = format(input);
-        assert_eq!(output, "# Heading\n\n```\ncode\n```\n");
+        assert_eq!(
+            output,
+            indoc! {"
+                # Heading
+
+                ```
+                code
+                ```
+            "}
+        );
     }
 
     #[test]
     fn test_blank_line_between_list_and_paragraph() {
-        let input = "- item\n\nAfter list.";
+        let input = indoc! {"
+            - item
+
+            After list."};
         let output = format(input);
-        assert_eq!(output, "- item\n\nAfter list.\n");
+        assert_eq!(
+            output,
+            indoc! {"
+                - item
+
+                After list.
+            "}
+        );
     }
 
     #[test]
     fn test_nested_list() {
-        let input = "- Item 1\n  - Nested\n- Item 2";
+        let input = indoc! {"
+            - Item 1
+              - Nested
+            - Item 2"};
         let output = format(input);
-        assert_eq!(output, "- Item 1\n  - Nested\n- Item 2\n");
+        assert_eq!(
+            output,
+            indoc! {"
+                - Item 1
+                  - Nested
+                - Item 2
+            "}
+        );
     }
 
     #[test]
@@ -1054,14 +1163,38 @@ mod tests {
     // Blank lines: multiple consecutive blank lines collapsed to one
     #[test]
     fn test_multiple_blank_lines_collapsed() {
-        assert_formats_to("First.\n\n\n\nSecond.", "First.\n\nSecond.\n");
+        assert_formats_to(
+            indoc! {"
+                First.
+
+
+
+                Second."},
+            indoc! {"
+                First.
+
+                Second.
+            "},
+        );
     }
 
     // List markers: * and + → -
     #[test]
     fn test_list_markers_to_dash() {
-        assert_formats_to("* Item 1\n* Item 2", "- Item 1\n- Item 2\n");
-        assert_formats_to("+ Item 1\n+ Item 2", "- Item 1\n- Item 2\n");
+        assert_formats_to(
+            "* Item 1\n* Item 2",
+            indoc! {"
+                - Item 1
+                - Item 2
+            "},
+        );
+        assert_formats_to(
+            "+ Item 1\n+ Item 2",
+            indoc! {"
+                - Item 1
+                - Item 2
+            "},
+        );
     }
 
     // Emphasis: _ / __ → * / **
@@ -1074,8 +1207,28 @@ mod tests {
     // Code fences: ~~~ → ``` (with and without lang tag)
     #[test]
     fn test_tilde_fence_to_backtick() {
-        assert_formats_to("~~~rust\ncode\n~~~", "```rust\ncode\n```\n");
-        assert_formats_to("~~~\ncode\n~~~", "```\ncode\n```\n");
+        assert_formats_to(
+            indoc! {"
+                ~~~rust
+                code
+                ~~~"},
+            indoc! {"
+                ```rust
+                code
+                ```
+            "},
+        );
+        assert_formats_to(
+            indoc! {"
+                ~~~
+                code
+                ~~~"},
+            indoc! {"
+                ```
+                code
+                ```
+            "},
+        );
     }
 
     // Horizontal rules: all styles → ---
@@ -1099,17 +1252,38 @@ mod tests {
     // Tables
     #[test]
     fn test_simple_table() {
-        let input = "| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |\n";
+        let input = indoc! {"
+            | A | B |
+            | --- | --- |
+            | 1 | 2 |
+            | 3 | 4 |
+        "};
         let output = format(input);
-        assert_eq!(output, "| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |\n");
+        assert_eq!(
+            output,
+            indoc! {"
+                | A | B |
+                | --- | --- |
+                | 1 | 2 |
+                | 3 | 4 |
+            "}
+        );
     }
 
     #[test]
     fn test_table_no_leading_pipes() {
         // GFM allows tables without leading/trailing pipes
         assert_formats_to(
-            "A | B\n--- | ---\n1 | 2\n",
-            "| A | B |\n| --- | --- |\n| 1 | 2 |\n",
+            indoc! {"
+                A | B
+                --- | ---
+                1 | 2
+            "},
+            indoc! {"
+                | A | B |
+                | --- | --- |
+                | 1 | 2 |
+            "},
         );
     }
 
@@ -1117,7 +1291,11 @@ mod tests {
     fn test_table_idempotent() {
         // Proptest uses random strings and is unlikely to generate valid table
         // syntax, so this structural idempotency check is worth keeping explicitly.
-        let input = "| A | B |\n| --- | --- |\n| 1 | 2 |\n";
+        let input = indoc! {"
+            | A | B |
+            | --- | --- |
+            | 1 | 2 |
+        "};
         let once = format(input);
         let twice = format(&once);
         assert_eq!(once, twice);
@@ -1125,21 +1303,41 @@ mod tests {
 
     #[test]
     fn test_table_with_inline_formatting() {
-        let input = "| **bold** | `code` |\n| --- | --- |\n| *em* | plain |\n";
+        let input = indoc! {"
+            | **bold** | `code` |
+            | --- | --- |
+            | *em* | plain |
+        "};
         let output = format(input);
         assert_eq!(
             output,
-            "| **bold** | `code` |\n| --- | --- |\n| *em* | plain |\n"
+            indoc! {"
+                | **bold** | `code` |
+                | --- | --- |
+                | *em* | plain |
+            "}
         );
     }
 
     #[test]
     fn test_table_followed_by_paragraph() {
-        let input = "| A | B |\n| --- | --- |\n| 1 | 2 |\n\nSome text.\n";
+        let input = indoc! {"
+            | A | B |
+            | --- | --- |
+            | 1 | 2 |
+
+            Some text.
+        "};
         let output = format(input);
         assert_eq!(
             output,
-            "| A | B |\n| --- | --- |\n| 1 | 2 |\n\nSome text.\n"
+            indoc! {"
+                | A | B |
+                | --- | --- |
+                | 1 | 2 |
+
+                Some text.
+            "}
         );
     }
 
@@ -1178,17 +1376,47 @@ mod tests {
     // keep the block inside the list item (3 spaces for `1. `, 2 for `- `).
     #[test]
     fn test_ordered_list_with_code_block() {
-        let canonical = "1. **Enable rule:**\n\n   ```toml\n   enabled = false\n   ```\n\n2. **Another item:**\n\n   ```toml\n   line_length = 100\n   ```\n";
+        let canonical = indoc! {"
+            1. **Enable rule:**
+
+               ```toml
+               enabled = false
+               ```
+
+            2. **Another item:**
+
+               ```toml
+               line_length = 100
+               ```
+        "};
         // Starting with `1. / 1.` triggers MD029 renumbering in the formatter.
         assert_formats_to(
-            "1. **Enable rule:**\n\n   ```toml\n   enabled = false\n   ```\n\n1. **Another item:**\n\n   ```toml\n   line_length = 100\n   ```\n",
+            indoc! {"
+                1. **Enable rule:**
+
+                   ```toml
+                   enabled = false
+                   ```
+
+                1. **Another item:**
+
+                   ```toml
+                   line_length = 100
+                   ```
+            "},
             canonical,
         );
     }
 
     #[test]
     fn test_unordered_list_with_code_block() {
-        let canonical = "- **Item:**\n\n  ```toml\n  enabled = false\n  ```\n";
+        let canonical = indoc! {"
+            - **Item:**
+
+              ```toml
+              enabled = false
+              ```
+        "};
         assert_formats_to(canonical, canonical);
     }
 
@@ -1198,7 +1426,11 @@ mod tests {
         // The opening fence lands on the same line as the marker ("-   ```"),
         // making the effective list margin 4. Content and closing fence must
         // both use 4-space indent so the closing fence stays inside the item.
-        let canonical = "-   ```\n    ¡\n    ```\n";
+        let canonical = indoc! {"
+            -   ```
+                ¡
+                ```
+        "};
         assert_formats_to(canonical, canonical);
     }
 

--- a/src/lint/engine.rs
+++ b/src/lint/engine.rs
@@ -206,6 +206,7 @@ fn toml_to_json(toml_val: toml::Value) -> Value {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use indoc::indoc;
 
     fn engine_all_rules() -> LintEngine {
         LintEngine::new(Config {
@@ -217,7 +218,10 @@ mod tests {
     #[test]
     fn test_disable_next_line_specific_rule() {
         // MD018: no space after hash. Line 2 has `#Heading` — suppressed by disable-next-line on line 1.
-        let content = "<!-- mdlint-disable-next-line MD018 -->\n#Heading without space\n";
+        let content = indoc! {"
+            <!-- mdlint-disable-next-line MD018 -->
+            #Heading without space
+        "};
         let engine = engine_all_rules();
         let violations = engine.lint_content(content).unwrap();
         assert!(
@@ -229,7 +233,11 @@ mod tests {
     #[test]
     fn test_disable_next_line_does_not_suppress_two_lines_ahead() {
         // The disable-next-line on line 1 suppresses line 2, NOT line 3
-        let content = "<!-- mdlint-disable-next-line MD018 -->\n# Good heading\n#Bad heading\n";
+        let content = indoc! {"
+            <!-- mdlint-disable-next-line MD018 -->
+            # Good heading
+            #Bad heading
+        "};
         let engine = engine_all_rules();
         let violations = engine.lint_content(content).unwrap();
         // MD018 on line 3 should still fire
@@ -242,8 +250,11 @@ mod tests {
     #[test]
     fn test_disable_enable_specific_rule() {
         // Disable MD041, then re-enable it; violations between should be suppressed
-        let content =
-            "<!-- mdlint-disable MD041 -->\nNo heading here\n<!-- mdlint-enable MD041 -->\n";
+        let content = indoc! {"
+            <!-- mdlint-disable MD041 -->
+            No heading here
+            <!-- mdlint-enable MD041 -->
+        "};
         let engine = engine_all_rules();
         let violations = engine.lint_content(content).unwrap();
         assert!(
@@ -254,7 +265,11 @@ mod tests {
 
     #[test]
     fn test_disable_all_rules() {
-        let content = "<!-- mdlint-disable -->\nNo heading here\n<!-- mdlint-enable -->\n";
+        let content = indoc! {"
+            <!-- mdlint-disable -->
+            No heading here
+            <!-- mdlint-enable -->
+        "};
         let engine = engine_all_rules();
         let violations = engine.lint_content(content).unwrap();
         // All rules suppressed from line 1 to line 2 (enable on line 3)
@@ -267,7 +282,10 @@ mod tests {
 
     #[test]
     fn test_no_inline_config_flag_disables_parsing() {
-        let content = "<!-- mdlint-disable MD041 -->\nNo heading here\n";
+        let content = indoc! {"
+            <!-- mdlint-disable MD041 -->
+            No heading here
+        "};
         let engine = LintEngine::new(Config {
             default_enabled: true,
             no_inline_config: true,
@@ -283,7 +301,12 @@ mod tests {
 
     #[test]
     fn test_disable_without_enable_suppresses_to_end() {
-        let content = "# Heading\n\n<!-- mdlint-disable MD013 -->\nA very long line that goes on and on and on and on and on and on and on and on and on and on and on and on and on\n";
+        let content = indoc! {"
+            # Heading
+
+            <!-- mdlint-disable MD013 -->
+            A very long line that goes on and on and on and on and on and on and on and on and on and on and on and on and on
+        "};
         let engine = engine_all_rules();
         let violations = engine.lint_content(content).unwrap();
         assert!(

--- a/src/lint/rules/md001.rs
+++ b/src/lint/rules/md001.rs
@@ -69,10 +69,15 @@ fn heading_level_to_u8(level: HeadingLevel) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_no_skipped_levels() {
-        let content = "# Heading 1\n## Heading 2\n### Heading 3\n## Heading 2 again";
+        let content = indoc! {"
+            # Heading 1
+            ## Heading 2
+            ### Heading 3
+            ## Heading 2 again"};
         let parser = MarkdownParser::new(content);
         let rule = MD001;
         let violations = rule.check(&parser, None);
@@ -94,7 +99,11 @@ mod tests {
 
     #[test]
     fn test_multiple_skips() {
-        let content = "# H1\n#### H4 - skipped 2 levels\n## H2\n##### H5 - skipped h3 and h4";
+        let content = indoc! {"
+            # H1
+            #### H4 - skipped 2 levels
+            ## H2
+            ##### H5 - skipped h3 and h4"};
         let parser = MarkdownParser::new(content);
         let rule = MD001;
         let violations = rule.check(&parser, None);
@@ -106,7 +115,12 @@ mod tests {
 
     #[test]
     fn test_decreasing_levels_ok() {
-        let content = "# H1\n## H2\n### H3\n## H2 back\n# H1 back";
+        let content = indoc! {"
+            # H1
+            ## H2
+            ### H3
+            ## H2 back
+            # H1 back"};
         let parser = MarkdownParser::new(content);
         let rule = MD001;
         let violations = rule.check(&parser, None);
@@ -117,7 +131,10 @@ mod tests {
     #[test]
     fn test_start_with_h2() {
         // Starting with h2 is allowed (no previous heading to compare to)
-        let content = "## H2 first\n### H3\n## H2 again";
+        let content = indoc! {"
+            ## H2 first
+            ### H3
+            ## H2 again"};
         let parser = MarkdownParser::new(content);
         let rule = MD001;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md003.rs
+++ b/src/lint/rules/md003.rs
@@ -127,10 +127,14 @@ impl Rule for MD003 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_consistent_atx() {
-        let content = "# Heading 1\n## Heading 2\n### Heading 3";
+        let content = indoc! {"
+            # Heading 1
+            ## Heading 2
+            ### Heading 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD003;
         let violations = rule.check(&parser, None);
@@ -140,7 +144,10 @@ mod tests {
 
     #[test]
     fn test_inconsistent_styles() {
-        let content = "# Heading 1\n## Heading 2 ##\n### Heading 3";
+        let content = indoc! {"
+            # Heading 1
+            ## Heading 2 ##
+            ### Heading 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD003;
         let violations = rule.check(&parser, None);
@@ -161,7 +168,12 @@ mod tests {
 
     #[test]
     fn test_setext_detection() {
-        let content = "Heading 1\n=========\n\nHeading 2\n---------";
+        let content = indoc! {"
+            Heading 1
+            =========
+
+            Heading 2
+            ---------"};
         let parser = MarkdownParser::new(content);
         let rule = MD003;
         let config = serde_json::json!({ "style": "consistent" });
@@ -173,7 +185,16 @@ mod tests {
     #[test]
     fn test_horizontal_rules_not_flagged() {
         // Horizontal rules (---) after blank lines should not be detected as setext headings
-        let content = "# Heading 1\n\n---\n\nContent here.\n\n***\n\nMore content.";
+        let content = indoc! {"
+            # Heading 1
+
+            ---
+
+            Content here.
+
+            ***
+
+            More content."};
         let parser = MarkdownParser::new(content);
         let rule = MD003;
         let violations = rule.check(&parser, None);
@@ -183,7 +204,14 @@ mod tests {
 
     #[test]
     fn test_setext_in_code_block_not_flagged() {
-        let content = "# Real heading\n\n```markdown\nSetext heading\n==============\n```\n";
+        let content = indoc! {"
+            # Real heading
+
+            ```markdown
+            Setext heading
+            ==============
+            ```
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD003;
         let config = serde_json::json!({ "style": "atx" });

--- a/src/lint/rules/md004.rs
+++ b/src/lint/rules/md004.rs
@@ -133,6 +133,7 @@ impl Rule for MD004 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -143,7 +144,10 @@ mod tests {
 
     #[test]
     fn test_consistent_asterisk() {
-        let content = "* Item 1\n* Item 2\n* Item 3";
+        let content = indoc! {"
+            * Item 1
+            * Item 2
+            * Item 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD004;
         let config = serde_json::json!({ "style": "consistent" });
@@ -154,7 +158,10 @@ mod tests {
 
     #[test]
     fn test_inconsistent_markers() {
-        let content = "* Item 1\n+ Item 2\n- Item 3";
+        let content = indoc! {"
+            * Item 1
+            + Item 2
+            - Item 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD004;
         let violations = rule.check(&parser, None);
@@ -175,7 +182,11 @@ mod tests {
 
     #[test]
     fn test_nested_lists() {
-        let content = "* Item 1\n  * Nested 1\n  * Nested 2\n* Item 2";
+        let content = indoc! {"
+            * Item 1
+              * Nested 1
+              * Nested 2
+            * Item 2"};
         let parser = MarkdownParser::new(content);
         let rule = MD004;
         let config = serde_json::json!({ "style": "consistent" });
@@ -187,7 +198,15 @@ mod tests {
     #[test]
     fn test_list_markers_in_code_block_not_flagged() {
         // List markers inside fenced code blocks must not be checked.
-        let content = "```\n* asterisk\n+ plus\n- dash\n```\n\n- real item\n";
+        let content = indoc! {"
+            ```
+            * asterisk
+            + plus
+            - dash
+            ```
+
+            - real item
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD004;
         let config = serde_json::json!({ "style": "dash" });
@@ -199,18 +218,19 @@ mod tests {
 
     #[test]
     fn test_markdown_syntax_in_code_block() {
-        let content = "# My Document
+        let content = indoc! {"
+            # My Document
 
-Here's a code block with markdown syntax:
+            Here's a code block with markdown syntax:
 
-```
-- This looks like a list item
-* This also looks like a list item
-+ And this one too
-```
+            ```
+            - This looks like a list item
+            * This also looks like a list item
+            + And this one too
+            ```
 
-- Real list item
-";
+            - Real list item
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD004;
         let violations = rule.check(&parser, None);
@@ -221,14 +241,15 @@ Here's a code block with markdown syntax:
 
     #[test]
     fn test_indented_code_block() {
-        let content = "Regular text
+        let content = indoc! {"
+            Regular text
 
-    - This is an indented code block
-    * Not a real list
-    + Just code
+                - This is an indented code block
+                * Not a real list
+                + Just code
 
-- Real list item
-";
+            - Real list item
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD004;
         let violations = rule.check(&parser, None);
@@ -239,27 +260,37 @@ Here's a code block with markdown syntax:
 
     #[test]
     fn test_fix_normalises_marker_to_dash() {
-        let content = "* Item 1\n* Item 2\n";
+        let content = indoc! {"
+            * Item 1
+            * Item 2
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD004;
         let config = serde_json::json!({ "style": "dash" });
         let violations = rule.check(&parser, Some(&config));
         assert_eq!(violations.len(), 2);
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "- Item 1\n- Item 2\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                - Item 1
+                - Item 2
+            "}
+        );
     }
 
     #[test]
     fn test_dash_in_code_block_with_real_list() {
-        let content = "* List item 1
+        let content = indoc! {"
+            * List item 1
 
-```python
-# Comment with -- dashes
-value = 10 - 5  # subtraction
-```
+            ```python
+            # Comment with -- dashes
+            value = 10 - 5  # subtraction
+            ```
 
-+ List item 2
-";
+            + List item 2
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD004;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md005.rs
+++ b/src/lint/rules/md005.rs
@@ -92,10 +92,16 @@ impl Rule for MD005 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_consistent_indentation() {
-        let content = "* Item 1\n* Item 2\n  * Nested 1\n  * Nested 2\n* Item 3";
+        let content = indoc! {"
+            * Item 1
+            * Item 2
+              * Nested 1
+              * Nested 2
+            * Item 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD005;
         let violations = rule.check(&parser, None);
@@ -105,7 +111,10 @@ mod tests {
 
     #[test]
     fn test_inconsistent_indentation() {
-        let content = "* Item 1\n * Item 2 - wrong indent\n* Item 3";
+        let content = indoc! {"
+            * Item 1
+             * Item 2 - wrong indent
+            * Item 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD005;
         let violations = rule.check(&parser, None);
@@ -115,7 +124,10 @@ mod tests {
 
     #[test]
     fn test_ordered_list() {
-        let content = "1. Item 1\n2. Item 2\n3. Item 3";
+        let content = indoc! {"
+            1. Item 1
+            2. Item 2
+            3. Item 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD005;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md006.rs
+++ b/src/lint/rules/md006.rs
@@ -32,6 +32,7 @@ impl Rule for MD006 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_list_at_start() {
@@ -67,7 +68,10 @@ mod tests {
 
     #[test]
     fn test_mixed() {
-        let content = "* Good\n  * Nested (violation)\n+ Also good";
+        let content = indoc! {"
+            * Good
+              * Nested (violation)
+            + Also good"};
         let parser = MarkdownParser::new(content);
         let rule = MD006;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md007.rs
+++ b/src/lint/rules/md007.rs
@@ -92,10 +92,16 @@ impl Rule for MD007 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_correct_indentation() {
-        let content = "* Item 1\n  * Nested 1\n    * Double nested\n  * Nested 2\n* Item 2";
+        let content = indoc! {"
+            * Item 1
+              * Nested 1
+                * Double nested
+              * Nested 2
+            * Item 2"};
         let parser = MarkdownParser::new(content);
         let rule = MD007;
         let violations = rule.check(&parser, None);
@@ -126,7 +132,11 @@ mod tests {
 
     #[test]
     fn test_multiple_levels() {
-        let content = "* Level 1\n  * Level 2\n    * Level 3\n      * Level 4";
+        let content = indoc! {"
+            * Level 1
+              * Level 2
+                * Level 3
+                  * Level 4"};
         let parser = MarkdownParser::new(content);
         let rule = MD007;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md009.rs
+++ b/src/lint/rules/md009.rs
@@ -71,6 +71,7 @@ impl Rule for MD009 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -81,7 +82,10 @@ mod tests {
 
     #[test]
     fn test_no_trailing_spaces() {
-        let content = "Line 1\nLine 2\nLine 3";
+        let content = indoc! {"
+            Line 1
+            Line 2
+            Line 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD009;
         let violations = rule.check(&parser, None);
@@ -131,6 +135,12 @@ mod tests {
         let rule = MD009;
         let violations = rule.check(&parser, None);
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "Line 1\nLine 2\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                Line 1
+                Line 2
+            "}
+        );
     }
 }

--- a/src/lint/rules/md010.rs
+++ b/src/lint/rules/md010.rs
@@ -88,6 +88,7 @@ impl Rule for MD010 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -98,7 +99,10 @@ mod tests {
 
     #[test]
     fn test_no_tabs() {
-        let content = "Line 1\n    Line 2\nLine 3";
+        let content = indoc! {"
+            Line 1
+                Line 2
+            Line 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD010;
         let violations = rule.check(&parser, None);
@@ -108,7 +112,10 @@ mod tests {
 
     #[test]
     fn test_hard_tabs() {
-        let content = "Line 1\n\tLine 2\nLine 3";
+        let content = indoc! {"
+            Line 1
+            \tLine 2
+            Line 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD010;
         let violations = rule.check(&parser, None);
@@ -120,7 +127,11 @@ mod tests {
 
     #[test]
     fn test_tabs_in_code_block() {
-        let content = "Text\n```\n\tcode\n```";
+        let content = indoc! {"
+            Text
+            ```
+            \tcode
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD010;
         let violations = rule.check(&parser, None);
@@ -131,7 +142,11 @@ mod tests {
 
     #[test]
     fn test_ignore_code_blocks() {
-        let content = "Text\n```\n\tcode\n```";
+        let content = indoc! {"
+            Text
+            ```
+            \tcode
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD010;
         let config = serde_json::json!({ "code_blocks": false });
@@ -142,7 +157,11 @@ mod tests {
 
     #[test]
     fn test_fix_replaces_tab_with_spaces() {
-        let content = "# Heading\n\n\tTabbed line\n";
+        let content = indoc! {"
+            # Heading
+
+            \tTabbed line
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD010;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md011.rs
+++ b/src/lint/rules/md011.rs
@@ -88,6 +88,7 @@ impl Rule for MD011 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_correct_link_syntax() {
@@ -144,7 +145,11 @@ mod tests {
     #[test]
     fn test_task_list_checkbox_not_flagged() {
         // (text)[ ] should not be flagged — the [ ] is a GFM task list checkbox
-        let content = "- [ ] Task item\n- [x] Done task\n- (description)[ ] another task\n";
+        let content = indoc! {"
+            - [ ] Task item
+            - [x] Done task
+            - (description)[ ] another task
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD011;
         let violations = rule.check(&parser, None);
@@ -154,15 +159,16 @@ mod tests {
 
     #[test]
     fn test_code_block_not_flagged() {
-        let content = "# Code Example
+        let content = indoc! {"
+            # Code Example
 
-```python
-result = function(param)[index]
-data = array(0)[key]
-```
+            ```python
+            result = function(param)[index]
+            data = array(0)[key]
+            ```
 
-This (is)[wrong] though.
-";
+            This (is)[wrong] though.
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD011;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md012.rs
+++ b/src/lint/rules/md012.rs
@@ -99,6 +99,7 @@ impl Rule for MD012 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -109,7 +110,12 @@ mod tests {
 
     #[test]
     fn test_no_consecutive_blanks() {
-        let content = "Line 1\n\nLine 2\n\nLine 3";
+        let content = indoc! {"
+            Line 1
+
+            Line 2
+
+            Line 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD012;
         let violations = rule.check(&parser, None);
@@ -119,7 +125,11 @@ mod tests {
 
     #[test]
     fn test_multiple_consecutive_blanks() {
-        let content = "Line 1\n\n\nLine 2";
+        let content = indoc! {"
+            Line 1
+
+
+            Line 2"};
         let parser = MarkdownParser::new(content);
         let rule = MD012;
         let violations = rule.check(&parser, None);
@@ -130,7 +140,11 @@ mod tests {
 
     #[test]
     fn test_custom_maximum() {
-        let content = "Line 1\n\n\nLine 2";
+        let content = indoc! {"
+            Line 1
+
+
+            Line 2"};
         let parser = MarkdownParser::new(content);
         let rule = MD012;
         let config = serde_json::json!({ "maximum": 2 });
@@ -141,7 +155,11 @@ mod tests {
 
     #[test]
     fn test_trailing_blank_lines() {
-        let content = "Line 1\n\n\n";
+        let content = indoc! {"
+            Line 1
+
+
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD012;
         let violations = rule.check(&parser, None);
@@ -151,12 +169,24 @@ mod tests {
 
     #[test]
     fn test_fix_removes_excess_blank_line() {
-        let content = "Line 1\n\n\nLine 2\n";
+        let content = indoc! {"
+            Line 1
+
+
+            Line 2
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD012;
         let violations = rule.check(&parser, None);
         assert_eq!(violations.len(), 1);
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "Line 1\n\nLine 2\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                Line 1
+
+                Line 2
+            "}
+        );
     }
 }

--- a/src/lint/rules/md013.rs
+++ b/src/lint/rules/md013.rs
@@ -158,10 +158,14 @@ impl Rule for MD013 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_short_lines() {
-        let content = "Short line\nAnother short line\nStill short";
+        let content = indoc! {"
+            Short line
+            Another short line
+            Still short"};
         let parser = MarkdownParser::new(content);
         let rule = MD013;
         let violations = rule.check(&parser, None);
@@ -206,7 +210,10 @@ mod tests {
 
     #[test]
     fn test_code_block_check() {
-        let content = "```\nThis is a very long line in a code block that exceeds the maximum allowed character count\n```";
+        let content = indoc! {"
+            ```
+            This is a very long line in a code block that exceeds the maximum allowed character count
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD013;
         let config = serde_json::json!({ "line_length": 80, "code_blocks": true });
@@ -217,7 +224,10 @@ mod tests {
 
     #[test]
     fn test_code_block_ignore() {
-        let content = "```\nThis is a very long line in a code block that exceeds the maximum allowed character count\n```";
+        let content = indoc! {"
+            ```
+            This is a very long line in a code block that exceeds the maximum allowed character count
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD013;
         let config = serde_json::json!({ "code_blocks": false });
@@ -288,7 +298,11 @@ mod tests {
 
     #[test]
     fn test_long_table_line() {
-        let content = "| Col1 | Col2 |\n|------|------|\n| A    | B    |\n| C    | D    |";
+        let content = indoc! {"
+            | Col1 | Col2 |
+            |------|------|
+            | A    | B    |
+            | C    | D    |"};
         let parser = MarkdownParser::new(content);
         let rule = MD013;
         let config = serde_json::json!({ "line_length": 10, "tables": true });
@@ -305,7 +319,11 @@ mod tests {
 
     #[test]
     fn test_long_table_line_ignored() {
-        let content = "| Col1 | Col2 |\n|------|------|\n| A    | B    |\n| C    | D    |";
+        let content = indoc! {"
+            | Col1 | Col2 |
+            |------|------|
+            | A    | B    |
+            | C    | D    |"};
         let parser = MarkdownParser::new(content);
         let rule = MD013;
         let config = serde_json::json!({ "line_length": 10, "tables": false });

--- a/src/lint/rules/md014.rs
+++ b/src/lint/rules/md014.rs
@@ -115,6 +115,7 @@ impl Rule for MD014 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -125,7 +126,11 @@ mod tests {
 
     #[test]
     fn test_no_dollar_signs() {
-        let content = "```bash\nls -la\necho hello\n```";
+        let content = indoc! {"
+            ```bash
+            ls -la
+            echo hello
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD014;
         let violations = rule.check(&parser, None);
@@ -135,7 +140,11 @@ mod tests {
 
     #[test]
     fn test_all_dollar_signs() {
-        let content = "```bash\n$ ls -la\n$ echo hello\n```";
+        let content = indoc! {"
+            ```bash
+            $ ls -la
+            $ echo hello
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD014;
         let violations = rule.check(&parser, None);
@@ -147,7 +156,13 @@ mod tests {
 
     #[test]
     fn test_dollar_with_output() {
-        let content = "```bash\n$ ls -la\ntotal 64\n$ echo hello\nhello\n```";
+        let content = indoc! {"
+            ```bash
+            $ ls -la
+            total 64
+            $ echo hello
+            hello
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD014;
         let violations = rule.check(&parser, None);
@@ -157,7 +172,10 @@ mod tests {
 
     #[test]
     fn test_non_shell_language() {
-        let content = "```python\n$ this is not a shell\n```";
+        let content = indoc! {"
+            ```python
+            $ this is not a shell
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD014;
         let violations = rule.check(&parser, None);
@@ -167,12 +185,25 @@ mod tests {
 
     #[test]
     fn test_fix_removes_dollar_signs() {
-        let content = "```bash\n$ ls -la\n$ echo hello\n```\n";
+        let content = indoc! {"
+            ```bash
+            $ ls -la
+            $ echo hello
+            ```
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD014;
         let violations = rule.check(&parser, None);
         assert_eq!(violations.len(), 2);
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "```bash\nls -la\necho hello\n```\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                ```bash
+                ls -la
+                echo hello
+                ```
+            "}
+        );
     }
 }

--- a/src/lint/rules/md018.rs
+++ b/src/lint/rules/md018.rs
@@ -77,6 +77,7 @@ impl Rule for MD018 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -87,7 +88,10 @@ mod tests {
 
     #[test]
     fn test_correct_spacing() {
-        let content = "# Heading 1\n## Heading 2\n### Heading 3";
+        let content = indoc! {"
+            # Heading 1
+            ## Heading 2
+            ### Heading 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD018;
         let violations = rule.check(&parser, None);
@@ -108,7 +112,10 @@ mod tests {
 
     #[test]
     fn test_multiple_violations() {
-        let content = "#First\n##Second\n### Correct";
+        let content = indoc! {"
+            #First
+            ##Second
+            ### Correct"};
         let parser = MarkdownParser::new(content);
         let rule = MD018;
         let violations = rule.check(&parser, None);
@@ -128,7 +135,13 @@ mod tests {
 
     #[test]
     fn test_heading_in_code_block_not_flagged() {
-        let content = "# Real heading\n\n```\n#NotAHeading\n```\n";
+        let content = indoc! {"
+            # Real heading
+
+            ```
+            #NotAHeading
+            ```
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD018;
         let violations = rule.check(&parser, None);
@@ -138,12 +151,23 @@ mod tests {
 
     #[test]
     fn test_fix_inserts_space_after_hash() {
-        let content = "#Heading\n\n##Another\n";
+        let content = indoc! {"
+            #Heading
+
+            ##Another
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD018;
         let violations = rule.check(&parser, None);
         assert_eq!(violations.len(), 2);
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "# Heading\n\n## Another\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                # Heading
+
+                ## Another
+            "}
+        );
     }
 }

--- a/src/lint/rules/md019.rs
+++ b/src/lint/rules/md019.rs
@@ -80,6 +80,7 @@ impl Rule for MD019 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -90,7 +91,10 @@ mod tests {
 
     #[test]
     fn test_correct_single_space() {
-        let content = "# Heading 1\n## Heading 2\n### Heading 3";
+        let content = indoc! {"
+            # Heading 1
+            ## Heading 2
+            ### Heading 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD019;
         let violations = rule.check(&parser, None);
@@ -122,7 +126,13 @@ mod tests {
 
     #[test]
     fn test_heading_in_code_block_not_flagged() {
-        let content = "# Real heading\n\n```\n##  WouldBeViolation\n```\n";
+        let content = indoc! {"
+            # Real heading
+
+            ```
+            ##  WouldBeViolation
+            ```
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD019;
         let violations = rule.check(&parser, None);
@@ -132,12 +142,23 @@ mod tests {
 
     #[test]
     fn test_fix_collapses_multiple_spaces() {
-        let content = "#  Too many spaces\n\n###   Even more\n";
+        let content = indoc! {"
+            #  Too many spaces
+
+            ###   Even more
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD019;
         let violations = rule.check(&parser, None);
         assert_eq!(violations.len(), 2);
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "# Too many spaces\n\n### Even more\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                # Too many spaces
+
+                ### Even more
+            "}
+        );
     }
 }

--- a/src/lint/rules/md022.rs
+++ b/src/lint/rules/md022.rs
@@ -111,6 +111,7 @@ impl Rule for MD022 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -121,7 +122,12 @@ mod tests {
 
     #[test]
     fn test_properly_surrounded() {
-        let content = "Paragraph\n\n# Heading\n\nAnother paragraph";
+        let content = indoc! {"
+            Paragraph
+
+            # Heading
+
+            Another paragraph"};
         let parser = MarkdownParser::new(content);
         let rule = MD022;
         let violations = rule.check(&parser, None);
@@ -131,7 +137,11 @@ mod tests {
 
     #[test]
     fn test_missing_blank_before() {
-        let content = "Paragraph\n# Heading\n\nContent";
+        let content = indoc! {"
+            Paragraph
+            # Heading
+
+            Content"};
         let parser = MarkdownParser::new(content);
         let rule = MD022;
         let violations = rule.check(&parser, None);
@@ -142,7 +152,10 @@ mod tests {
 
     #[test]
     fn test_missing_blank_after() {
-        let content = "\n# Heading\nContent";
+        let content = indoc! {"
+
+            # Heading
+            Content"};
         let parser = MarkdownParser::new(content);
         let rule = MD022;
         let violations = rule.check(&parser, None);
@@ -153,7 +166,10 @@ mod tests {
 
     #[test]
     fn test_first_line() {
-        let content = "# Heading\n\nContent";
+        let content = indoc! {"
+            # Heading
+
+            Content"};
         let parser = MarkdownParser::new(content);
         let rule = MD022;
         let violations = rule.check(&parser, None);
@@ -163,25 +179,49 @@ mod tests {
 
     #[test]
     fn test_fix_inserts_blank_before_heading() {
-        let content = "Paragraph\n# Heading\n\nContent\n";
+        let content = indoc! {"
+            Paragraph
+            # Heading
+
+            Content
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD022;
         let violations = rule.check(&parser, None);
         assert_eq!(violations.len(), 1);
         assert!(violations[0].message.contains("before"));
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "Paragraph\n\n# Heading\n\nContent\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                Paragraph
+
+                # Heading
+
+                Content
+            "}
+        );
     }
 
     #[test]
     fn test_fix_inserts_blank_after_heading() {
-        let content = "# Heading\nContent\n";
+        let content = indoc! {"
+            # Heading
+            Content
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD022;
         let violations = rule.check(&parser, None);
         assert_eq!(violations.len(), 1);
         assert!(violations[0].message.contains("after"));
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "# Heading\n\nContent\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                # Heading
+
+                Content
+            "}
+        );
     }
 }

--- a/src/lint/rules/md023.rs
+++ b/src/lint/rules/md023.rs
@@ -72,6 +72,7 @@ impl Rule for MD023 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -82,7 +83,10 @@ mod tests {
 
     #[test]
     fn test_correct_headings() {
-        let content = "# Heading 1\n## Heading 2\n### Heading 3";
+        let content = indoc! {"
+            # Heading 1
+            ## Heading 2
+            ### Heading 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD023;
         let violations = rule.check(&parser, None);
@@ -138,12 +142,23 @@ mod tests {
 
     #[test]
     fn test_fix_removes_leading_whitespace() {
-        let content = " # Indented heading\n\nParagraph.\n";
+        let content = indoc! {"
+             # Indented heading
+
+            Paragraph.
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD023;
         let violations = rule.check(&parser, None);
         assert_eq!(violations.len(), 1);
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "# Indented heading\n\nParagraph.\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                # Indented heading
+
+                Paragraph.
+            "}
+        );
     }
 }

--- a/src/lint/rules/md024.rs
+++ b/src/lint/rules/md024.rs
@@ -118,10 +118,14 @@ impl Rule for MD024 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_unique_headings() {
-        let content = "# Heading 1\n## Heading 2\n### Heading 3";
+        let content = indoc! {"
+            # Heading 1
+            ## Heading 2
+            ### Heading 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD024;
         let violations = rule.check(&parser, None);
@@ -131,7 +135,10 @@ mod tests {
 
     #[test]
     fn test_duplicate_headings() {
-        let content = "# Heading\n## Content\n# Heading";
+        let content = indoc! {"
+            # Heading
+            ## Content
+            # Heading"};
         let parser = MarkdownParser::new(content);
         let rule = MD024;
         let violations = rule.check(&parser, None);
@@ -142,7 +149,10 @@ mod tests {
 
     #[test]
     fn test_siblings_only_different_levels() {
-        let content = "# Heading\n## Heading\n### Heading";
+        let content = indoc! {"
+            # Heading
+            ## Heading
+            ### Heading"};
         let parser = MarkdownParser::new(content);
         let rule = MD024;
         let config = serde_json::json!({ "siblings_only": true });
@@ -153,7 +163,10 @@ mod tests {
 
     #[test]
     fn test_siblings_only_same_level() {
-        let content = "## Heading\n## Content\n## Heading";
+        let content = indoc! {"
+            ## Heading
+            ## Content
+            ## Heading"};
         let parser = MarkdownParser::new(content);
         let rule = MD024;
         let config = serde_json::json!({ "siblings_only": true });
@@ -165,7 +178,12 @@ mod tests {
     #[test]
     fn test_headings_with_inline_code() {
         // Headings with different inline code should not be duplicates
-        let content = "#### `mdlint check`\n\nSome text\n\n#### `mdlint format`";
+        let content = indoc! {"
+            #### `mdlint check`
+
+            Some text
+
+            #### `mdlint format`"};
         let parser = MarkdownParser::new(content);
         let rule = MD024;
         let violations = rule.check(&parser, None);
@@ -180,7 +198,12 @@ mod tests {
     #[test]
     fn test_duplicate_code_headings() {
         // Headings with same inline code should be duplicates
-        let content = "#### `mdlint check`\n\nSome text\n\n#### `mdlint check`";
+        let content = indoc! {"
+            #### `mdlint check`
+
+            Some text
+
+            #### `mdlint check`"};
         let parser = MarkdownParser::new(content);
         let rule = MD024;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md025.rs
+++ b/src/lint/rules/md025.rs
@@ -58,10 +58,14 @@ impl Rule for MD025 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_single_h1() {
-        let content = "# Title\n## Section\n### Subsection";
+        let content = indoc! {"
+            # Title
+            ## Section
+            ### Subsection"};
         let parser = MarkdownParser::new(content);
         let rule = MD025;
         let violations = rule.check(&parser, None);
@@ -71,7 +75,10 @@ mod tests {
 
     #[test]
     fn test_multiple_h1() {
-        let content = "# First Title\n## Section\n# Second Title";
+        let content = indoc! {"
+            # First Title
+            ## Section
+            # Second Title"};
         let parser = MarkdownParser::new(content);
         let rule = MD025;
         let violations = rule.check(&parser, None);
@@ -82,7 +89,10 @@ mod tests {
 
     #[test]
     fn test_three_h1() {
-        let content = "# First\n# Second\n# Third";
+        let content = indoc! {"
+            # First
+            # Second
+            # Third"};
         let parser = MarkdownParser::new(content);
         let rule = MD025;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md027.rs
+++ b/src/lint/rules/md027.rs
@@ -72,6 +72,7 @@ impl Rule for MD027 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -124,12 +125,21 @@ mod tests {
 
     #[test]
     fn test_fix_collapses_blockquote_spaces() {
-        let content = ">  Too many spaces\n> Correct line\n";
+        let content = indoc! {"
+            >  Too many spaces
+            > Correct line
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD027;
         let violations = rule.check(&parser, None);
         assert_eq!(violations.len(), 1);
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "> Too many spaces\n> Correct line\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                > Too many spaces
+                > Correct line
+            "}
+        );
     }
 }

--- a/src/lint/rules/md028.rs
+++ b/src/lint/rules/md028.rs
@@ -76,10 +76,14 @@ impl Rule for MD028 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_continuous_blockquote() {
-        let content = "> Line 1\n> Line 2\n> Line 3";
+        let content = indoc! {"
+            > Line 1
+            > Line 2
+            > Line 3"};
         let parser = MarkdownParser::new(content);
         let rule = MD028;
         let violations = rule.check(&parser, None);
@@ -89,7 +93,10 @@ mod tests {
 
     #[test]
     fn test_blank_inside_blockquote() {
-        let content = "> Line 1\n\n> Line 2";
+        let content = indoc! {"
+            > Line 1
+
+            > Line 2"};
         let parser = MarkdownParser::new(content);
         let rule = MD028;
         let violations = rule.check(&parser, None);
@@ -100,7 +107,10 @@ mod tests {
 
     #[test]
     fn test_blank_ends_blockquote() {
-        let content = "> Line 1\n\nNormal text";
+        let content = indoc! {"
+            > Line 1
+
+            Normal text"};
         let parser = MarkdownParser::new(content);
         let rule = MD028;
         let violations = rule.check(&parser, None);
@@ -110,7 +120,11 @@ mod tests {
 
     #[test]
     fn test_multiple_blank_lines() {
-        let content = "> Line 1\n\n\n> Line 2";
+        let content = indoc! {"
+            > Line 1
+
+
+            > Line 2"};
         let parser = MarkdownParser::new(content);
         let rule = MD028;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md029.rs
+++ b/src/lint/rules/md029.rs
@@ -132,6 +132,7 @@ fn parse_item_number(trimmed: &str) -> Option<usize> {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -142,7 +143,10 @@ mod tests {
 
     #[test]
     fn test_ordered_sequence() {
-        let content = "1. First\n2. Second\n3. Third";
+        let content = indoc! {"
+            1. First
+            2. Second
+            3. Third"};
         let parser = MarkdownParser::new(content);
         let rule = MD029;
         let config = serde_json::json!({ "style": "ordered" });
@@ -153,7 +157,10 @@ mod tests {
 
     #[test]
     fn test_all_ones() {
-        let content = "1. First\n1. Second\n1. Third";
+        let content = indoc! {"
+            1. First
+            1. Second
+            1. Third"};
         let parser = MarkdownParser::new(content);
         let rule = MD029;
         let violations = rule.check(&parser, None);
@@ -166,7 +173,10 @@ mod tests {
 
     #[test]
     fn test_wrong_sequence() {
-        let content = "1. First\n3. Third - wrong\n4. Fourth";
+        let content = indoc! {"
+            1. First
+            3. Third - wrong
+            4. Fourth"};
         let parser = MarkdownParser::new(content);
         let rule = MD029;
         let violations = rule.check(&parser, None);
@@ -203,10 +213,11 @@ mod tests {
     #[test]
     fn test_list_with_backticks() {
         // Test numbered list where items contain backticks
-        let content = "1. Command-line options (`--config`)\n\
-                       2. Local directory config (`mdlint.toml` in current dir)\n\
-                       3. Parent directory configs (walking up to root)\n\
-                       4. Default configuration";
+        let content = indoc! {"
+            1. Command-line options (`--config`)
+            2. Local directory config (`mdlint.toml` in current dir)
+            3. Parent directory configs (walking up to root)
+            4. Default configuration"};
         let parser = MarkdownParser::new(content);
         let rule = MD029;
         let config = serde_json::json!({ "style": "ordered" });
@@ -217,7 +228,10 @@ mod tests {
 
     #[test]
     fn test_fix_populated_for_wrong_number() {
-        let content = "1. First\n1. Second\n1. Third";
+        let content = indoc! {"
+            1. First
+            1. Second
+            1. Third"};
         let parser = MarkdownParser::new(content);
         let rule = MD029;
         let violations = rule.check(&parser, None);
@@ -233,7 +247,12 @@ mod tests {
 
     #[test]
     fn test_fix_indented_list() {
-        let content = "1. First\n\n   text\n\n1. Second";
+        let content = indoc! {"
+            1. First
+
+               text
+
+            1. Second"};
         let parser = MarkdownParser::new(content);
         let rule = MD029;
         let violations = rule.check(&parser, None);
@@ -246,19 +265,44 @@ mod tests {
 
     #[test]
     fn test_fix_renumbers_list() {
-        let content = "1. First\n1. Second\n1. Third\n";
+        let content = indoc! {"
+            1. First
+            1. Second
+            1. Third
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD029;
         let violations = rule.check(&parser, None);
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "1. First\n2. Second\n3. Third\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                1. First
+                2. Second
+                3. Third
+            "}
+        );
     }
 
     #[test]
     fn test_code_block_breaks_list() {
         // An unindented code block breaks CommonMark list continuity.
         // Each numbered item is its own single-item list starting at 1.
-        let content = "1. First item\n\n```\ncode\n```\n\n1. Second item\n\n```\ncode\n```\n\n1. Third item\n";
+        let content = indoc! {"
+            1. First item
+
+            ```
+            code
+            ```
+
+            1. Second item
+
+            ```
+            code
+            ```
+
+            1. Third item
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD029;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md030.rs
+++ b/src/lint/rules/md030.rs
@@ -235,10 +235,15 @@ fn is_table_separator(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_correct_spacing() {
-        let content = "* Item 1\n+ Item 2\n- Item 3\n1. Ordered";
+        let content = indoc! {"
+            * Item 1
+            + Item 2
+            - Item 3
+            1. Ordered"};
         let parser = MarkdownParser::new(content);
         let rule = MD030;
         let violations = rule.check(&parser, None);
@@ -282,10 +287,11 @@ mod tests {
     #[test]
     fn test_bold_not_list_marker() {
         // Bold/emphasis at start of line should not be treated as list marker
-        let content = "**Slice-specific schemas** → some text\n\
-                       **Bold text** at start\n\
-                       *Italic text* here\n\
-                       __Also bold__ text";
+        let content = indoc! {"
+            **Slice-specific schemas** → some text
+            **Bold text** at start
+            *Italic text* here
+            __Also bold__ text"};
         let parser = MarkdownParser::new(content);
         let rule = MD030;
         let violations = rule.check(&parser, None);
@@ -300,9 +306,10 @@ mod tests {
     #[test]
     fn test_actual_list_with_bold() {
         // Actual list items can contain bold text
-        let content = "* **Bold** item\n\
-                       + *Italic* item\n\
-                       - Normal item";
+        let content = indoc! {"
+            * **Bold** item
+            + *Italic* item
+            - Normal item"};
         let parser = MarkdownParser::new(content);
         let rule = MD030;
         let violations = rule.check(&parser, None);
@@ -313,19 +320,20 @@ mod tests {
     #[test]
     fn test_horizontal_rules_not_list_markers() {
         // Horizontal rules should not trigger MD030 violations
-        let content = "# Heading\n\
-                       \n\
-                       ---\n\
-                       \n\
-                       More content\n\
-                       \n\
-                       ***\n\
-                       \n\
-                       ___\n\
-                       \n\
-                       * * *\n\
-                       \n\
-                       - - -";
+        let content = indoc! {"
+            # Heading
+
+            ---
+
+            More content
+
+            ***
+
+            ___
+
+            * * *
+
+            - - -"};
         let parser = MarkdownParser::new(content);
         let rule = MD030;
         let violations = rule.check(&parser, None);
@@ -340,15 +348,16 @@ mod tests {
     #[test]
     fn test_code_blocks_not_checked() {
         // Code blocks should not trigger MD030 violations
-        let content = "# Heading\n\
-                       \n\
-                       ```\n\
-                       --config <CONFIG>\n\
-                       --fix\n\
-                       -h, --help\n\
-                       ```\n\
-                       \n\
-                       Normal text with `-h` inline code.";
+        let content = indoc! {"
+            # Heading
+
+            ```
+            --config <CONFIG>
+            --fix
+            -h, --help
+            ```
+
+            Normal text with `-h` inline code."};
         let parser = MarkdownParser::new(content);
         let rule = MD030;
         let violations = rule.check(&parser, None);
@@ -363,11 +372,12 @@ mod tests {
     #[test]
     fn test_real_list_after_code_block() {
         // Real list markers outside code blocks should still be checked
-        let content = "```\n\
-                       --config\n\
-                       ```\n\
-                       \n\
-                       *Item without space";
+        let content = indoc! {"
+            ```
+            --config
+            ```
+
+            *Item without space"};
         let parser = MarkdownParser::new(content);
         let rule = MD030;
         let violations = rule.check(&parser, None);
@@ -383,10 +393,11 @@ mod tests {
     #[test]
     fn test_table_separator_not_list() {
         // Table separator lines should not trigger MD030 violations
-        let content = "Rule  | Description\n\
-                       ------|------------\n\
-                       MD001 | First rule\n\
-                       MD002 | Second rule";
+        let content = indoc! {"
+            Rule  | Description
+            ------|------------
+            MD001 | First rule
+            MD002 | Second rule"};
         let parser = MarkdownParser::new(content);
         let rule = MD030;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md031.rs
+++ b/src/lint/rules/md031.rs
@@ -121,10 +121,18 @@ impl Rule for MD031 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_properly_surrounded() {
-        let content = "Text\n\n```\ncode\n```\n\nMore text";
+        let content = indoc! {"
+            Text
+
+            ```
+            code
+            ```
+
+            More text"};
         let parser = MarkdownParser::new(content);
         let rule = MD031;
         let violations = rule.check(&parser, None);
@@ -134,7 +142,13 @@ mod tests {
 
     #[test]
     fn test_missing_blank_before() {
-        let content = "Text\n```\ncode\n```\n\nMore text";
+        let content = indoc! {"
+            Text
+            ```
+            code
+            ```
+
+            More text"};
         let parser = MarkdownParser::new(content);
         let rule = MD031;
         let violations = rule.check(&parser, None);
@@ -145,7 +159,13 @@ mod tests {
 
     #[test]
     fn test_missing_blank_after() {
-        let content = "Text\n\n```\ncode\n```\nMore text";
+        let content = indoc! {"
+            Text
+
+            ```
+            code
+            ```
+            More text"};
         let parser = MarkdownParser::new(content);
         let rule = MD031;
         let violations = rule.check(&parser, None);
@@ -156,7 +176,12 @@ mod tests {
 
     #[test]
     fn test_first_line() {
-        let content = "```\ncode\n```\n\nText";
+        let content = indoc! {"
+            ```
+            code
+            ```
+
+            Text"};
         let parser = MarkdownParser::new(content);
         let rule = MD031;
         let violations = rule.check(&parser, None);
@@ -167,7 +192,14 @@ mod tests {
     #[test]
     fn test_numbered_list_with_code_block() {
         // Test that code blocks in numbered lists get proper fixes
-        let content = "1. **Enable/Disable a rule:**\n   ```toml\n   [rules.MD013]\n   enabled = false\n   ```\n\n2. **Next item**";
+        let content = indoc! {"
+            1. **Enable/Disable a rule:**
+               ```toml
+               [rules.MD013]
+               enabled = false
+               ```
+
+            2. **Next item**"};
         let parser = MarkdownParser::new(content);
         let rule = MD031;
         let violations = rule.check(&parser, None);
@@ -190,7 +222,12 @@ mod tests {
     fn test_fix_creates_blank_line() {
         use crate::fix::Fixer;
 
-        let content = "Text\n```\ncode\n```\nMore";
+        let content = indoc! {"
+            Text
+            ```
+            code
+            ```
+            More"};
         let parser = MarkdownParser::new(content);
         let rule = MD031;
         let violations = rule.check(&parser, None);
@@ -203,7 +240,14 @@ mod tests {
         let result = runner.apply_fixes_to_content(content, &fixes).unwrap();
 
         // Verify blank lines were added
-        let expected = "Text\n\n```\ncode\n```\n\nMore";
+        let expected = indoc! {"
+            Text
+
+            ```
+            code
+            ```
+
+            More"};
         assert_eq!(result, expected);
     }
 }

--- a/src/lint/rules/md032.rs
+++ b/src/lint/rules/md032.rs
@@ -199,10 +199,17 @@ fn get_list_marker(trimmed: &str) -> Option<ListMarker> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_properly_surrounded() {
-        let content = "Text before\n\n* Item 1\n* Item 2\n\nText after";
+        let content = indoc! {"
+            Text before
+
+            * Item 1
+            * Item 2
+
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);
@@ -212,7 +219,12 @@ mod tests {
 
     #[test]
     fn test_missing_blank_before() {
-        let content = "Text before\n* Item 1\n* Item 2\n\nText after";
+        let content = indoc! {"
+            Text before
+            * Item 1
+            * Item 2
+
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);
@@ -223,7 +235,12 @@ mod tests {
 
     #[test]
     fn test_missing_blank_after() {
-        let content = "Text before\n\n* Item 1\n* Item 2\nText after";
+        let content = indoc! {"
+            Text before
+
+            * Item 1
+            * Item 2
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);
@@ -234,7 +251,11 @@ mod tests {
 
     #[test]
     fn test_first_line() {
-        let content = "* Item 1\n* Item 2\n\nText after";
+        let content = indoc! {"
+            * Item 1
+            * Item 2
+
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);
@@ -245,7 +266,14 @@ mod tests {
     #[test]
     fn test_wrapped_list_item() {
         // List items that wrap to multiple lines should not be treated as list ending
-        let content = "Text before\n\n* This is a long list item\n  that wraps to the next line\n* Item 2\n\nText after";
+        let content = indoc! {"
+            Text before
+
+            * This is a long list item
+              that wraps to the next line
+            * Item 2
+
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);
@@ -257,7 +285,16 @@ mod tests {
     #[test]
     fn test_multiple_wrapped_lines() {
         // Multiple continuation lines in a single list item
-        let content = "Text\n\n* Item with multiple\n  lines of text\n  spanning across\n  multiple lines\n* Item 2\n\nText after";
+        let content = indoc! {"
+            Text
+
+            * Item with multiple
+              lines of text
+              spanning across
+              multiple lines
+            * Item 2
+
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);
@@ -269,8 +306,15 @@ mod tests {
     #[test]
     fn test_wrapped_with_nested_list() {
         // Wrapped items with nested list
-        let content =
-            "Text\n\n* Item 1 that\n  wraps across lines\n  * Nested item\n* Item 2\n\nText after";
+        let content = indoc! {"
+            Text
+
+            * Item 1 that
+              wraps across lines
+              * Nested item
+            * Item 2
+
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);
@@ -281,7 +325,15 @@ mod tests {
 
     #[test]
     fn test_list_in_code_block_not_flagged() {
-        let content = "Text before\n\n```markdown\n- item 1\n- item 2\n```\n\nText after";
+        let content = indoc! {"
+            Text before
+
+            ```markdown
+            - item 1
+            - item 2
+            ```
+
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);
@@ -292,7 +344,14 @@ mod tests {
     #[test]
     fn test_mixed_markers_are_separate_lists() {
         // Different list markers are treated as separate lists
-        let content = "Text\n\n* Item asterisk\n+ Item plus\n- Item dash\n\nText after";
+        let content = indoc! {"
+            Text
+
+            * Item asterisk
+            + Item plus
+            - Item dash
+
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);
@@ -310,7 +369,14 @@ mod tests {
         // text or the next sibling item, is not a set of separate top-level lists
         // and must not be flagged. This is exactly the output `mdlint format`
         // produces for this construct.
-        let content = "# Example\n\n- First item:\n  1. One\n  2. Two\n- Second item\n";
+        let content = indoc! {"
+            # Example
+
+            - First item:
+              1. One
+              2. Two
+            - Second item
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);
@@ -323,7 +389,16 @@ mod tests {
         // Same construct as above, but with the blank lines that make the outer
         // list loose. Both forms are valid CommonMark and neither should be
         // flagged by MD032.
-        let content = "# Example\n\n- First item:\n\n  1. One\n  2. Two\n\n- Second item\n";
+        let content = indoc! {"
+            # Example
+
+            - First item:
+
+              1. One
+              2. Two
+
+            - Second item
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD032;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md033.rs
+++ b/src/lint/rules/md033.rs
@@ -91,10 +91,14 @@ fn extract_tag_name(html: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_no_html() {
-        let content = "# Heading\n\nNormal **markdown** text.";
+        let content = indoc! {"
+            # Heading
+
+            Normal **markdown** text."};
         let parser = MarkdownParser::new(content);
         let rule = MD033;
         let violations = rule.check(&parser, None);
@@ -128,7 +132,10 @@ mod tests {
 
     #[test]
     fn test_block_html() {
-        let content = "<div>\nContent\n</div>";
+        let content = indoc! {"
+            <div>
+            Content
+            </div>"};
         let parser = MarkdownParser::new(content);
         let rule = MD033;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md034.rs
+++ b/src/lint/rules/md034.rs
@@ -71,6 +71,7 @@ impl Rule for MD034 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_no_bare_url() {
@@ -115,7 +116,10 @@ mod tests {
 
     #[test]
     fn test_url_in_code_block() {
-        let content = "```shell\ncurl -LO https://example.com/file.tar.gz\n```";
+        let content = indoc! {"
+            ```shell
+            curl -LO https://example.com/file.tar.gz
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD034;
         let violations = rule.check(&parser, None);
@@ -203,7 +207,10 @@ mod tests {
     #[test]
     fn test_url_in_reference_definition() {
         // Regression test for https://github.com/swanysimon/mdlint/issues/53
-        let content = "Here a [reference] is used.\n\n[reference]: https://example.com/";
+        let content = indoc! {"
+            Here a [reference] is used.
+
+            [reference]: https://example.com/"};
         let parser = MarkdownParser::new(content);
         let rule = MD034;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md035.rs
+++ b/src/lint/rules/md035.rs
@@ -120,6 +120,7 @@ fn get_hr_style(line: &str) -> String {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -130,7 +131,12 @@ mod tests {
 
     #[test]
     fn test_consistent_style() {
-        let content = "---\n\nContent\n\n---";
+        let content = indoc! {"
+            ---
+
+            Content
+
+            ---"};
         let parser = MarkdownParser::new(content);
         let rule = MD035;
         let violations = rule.check(&parser, None);
@@ -140,7 +146,12 @@ mod tests {
 
     #[test]
     fn test_inconsistent_style() {
-        let content = "---\n\nContent\n\n***";
+        let content = indoc! {"
+            ---
+
+            Content
+
+            ***"};
         let parser = MarkdownParser::new(content);
         let rule = MD035;
         let violations = rule.check(&parser, None);
@@ -150,7 +161,10 @@ mod tests {
 
     #[test]
     fn test_enforced_style() {
-        let content = "***\n\nContent";
+        let content = indoc! {"
+            ***
+
+            Content"};
         let parser = MarkdownParser::new(content);
         let rule = MD035;
         let config = serde_json::json!({ "style": "---" });
@@ -161,7 +175,13 @@ mod tests {
 
     #[test]
     fn test_hr_in_code_block_not_flagged() {
-        let content = "---\n\n```markdown\n=========\n```\n";
+        let content = indoc! {"
+            ---
+
+            ```markdown
+            =========
+            ```
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD035;
         let violations = rule.check(&parser, None);
@@ -171,7 +191,12 @@ mod tests {
 
     #[test]
     fn test_with_spaces() {
-        let content = "* * *\n\nContent\n\n* * *";
+        let content = indoc! {"
+            * * *
+
+            Content
+
+            * * *"};
         let parser = MarkdownParser::new(content);
         let rule = MD035;
         let config = serde_json::json!({ "style": "consistent" });
@@ -182,13 +207,24 @@ mod tests {
 
     #[test]
     fn test_fix_normalises_hr_to_dashes() {
-        let content = "***\n\nContent\n";
+        let content = indoc! {"
+            ***
+
+            Content
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD035;
         let config = serde_json::json!({ "style": "---" });
         let violations = rule.check(&parser, Some(&config));
         assert_eq!(violations.len(), 1);
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "---\n\nContent\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                ---
+
+                Content
+            "}
+        );
     }
 }

--- a/src/lint/rules/md036.rs
+++ b/src/lint/rules/md036.rs
@@ -107,6 +107,7 @@ fn is_emphasis_only_line(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_real_heading() {
@@ -120,7 +121,10 @@ mod tests {
 
     #[test]
     fn test_emphasis_as_heading() {
-        let content = "**Summary**\n\nSome content";
+        let content = indoc! {"
+            **Summary**
+
+            Some content"};
         let parser = MarkdownParser::new(content);
         let rule = MD036;
         let violations = rule.check(&parser, None);
@@ -150,7 +154,10 @@ mod tests {
 
     #[test]
     fn test_emphasis_outside_code_block_still_flags() {
-        let content = "*2026-05-12*\n\nSome content";
+        let content = indoc! {"
+            *2026-05-12*
+
+            Some content"};
         let parser = MarkdownParser::new(content);
         let rule = MD036;
         let violations = rule.check(&parser, None);
@@ -160,7 +167,13 @@ mod tests {
 
     #[test]
     fn test_emphasis_inside_fenced_code_block_not_flagged() {
-        let content = "# Example\n\n```text\n*2026-05-12*\n```\n";
+        let content = indoc! {"
+            # Example
+
+            ```text
+            *2026-05-12*
+            ```
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD036;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md037.rs
+++ b/src/lint/rules/md037.rs
@@ -202,6 +202,7 @@ impl Rule for MD037 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_correct_emphasis() {
@@ -245,7 +246,23 @@ mod tests {
 
     #[test]
     fn test_code_block_with_underscores() {
-        let content = "Normal text\n\n```sql\nCREATE POLICY territory_contact_access ON contacts\n  FOR SELECT\n  USING (\n    territory_id IN (\n      SELECT territory_id\n      FROM user_territory_assignments\n      WHERE user_id = current_setting('app.current_user_id')::uuid\n        AND (valid_to IS NULL OR valid_to > NOW())\n    )\n  );\n```\n\nMore text";
+        let content = indoc! {"
+            Normal text
+
+            ```sql
+            CREATE POLICY territory_contact_access ON contacts
+              FOR SELECT
+              USING (
+                territory_id IN (
+                  SELECT territory_id
+                  FROM user_territory_assignments
+                  WHERE user_id = current_setting('app.current_user_id')::uuid
+                    AND (valid_to IS NULL OR valid_to > NOW())
+                )
+              );
+            ```
+
+            More text"};
         let parser = MarkdownParser::new(content);
         let rule = MD037;
         let violations = rule.check(&parser, None);
@@ -267,7 +284,10 @@ mod tests {
 
     #[test]
     fn test_typescript_multiplication() {
-        let content = "```typescript\nconst result = value_a * value_b * value_c;\n```";
+        let content = indoc! {"
+            ```typescript
+            const result = value_a * value_b * value_c;
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD037;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md040.rs
+++ b/src/lint/rules/md040.rs
@@ -71,10 +71,14 @@ impl Rule for MD040 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_with_language() {
-        let content = "```rust\nlet x = 5;\n```";
+        let content = indoc! {"
+            ```rust
+            let x = 5;
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD040;
         let violations = rule.check(&parser, None);
@@ -84,7 +88,10 @@ mod tests {
 
     #[test]
     fn test_without_language() {
-        let content = "```\ncode here\n```";
+        let content = indoc! {"
+            ```
+            code here
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD040;
         let config = serde_json::json!({ "allowed_languages": ["rust", "python"] });
@@ -96,7 +103,10 @@ mod tests {
 
     #[test]
     fn test_allowed_languages() {
-        let content = "```javascript\ncode here\n```";
+        let content = indoc! {"
+            ```javascript
+            code here
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD040;
         let config = serde_json::json!({ "allowed_languages": ["rust", "python"] });

--- a/src/lint/rules/md041.rs
+++ b/src/lint/rules/md041.rs
@@ -94,10 +94,14 @@ impl Rule for MD041 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_starts_with_h1() {
-        let content = "# Heading\n\nContent";
+        let content = indoc! {"
+            # Heading
+
+            Content"};
         let parser = MarkdownParser::new(content);
         let rule = MD041;
         let violations = rule.check(&parser, None);
@@ -107,7 +111,10 @@ mod tests {
 
     #[test]
     fn test_starts_with_text() {
-        let content = "Some text\n\n# Heading";
+        let content = indoc! {"
+            Some text
+
+            # Heading"};
         let parser = MarkdownParser::new(content);
         let rule = MD041;
         let violations = rule.check(&parser, None);
@@ -117,7 +124,10 @@ mod tests {
 
     #[test]
     fn test_starts_with_h2() {
-        let content = "## Heading\n\nContent";
+        let content = indoc! {"
+            ## Heading
+
+            Content"};
         let parser = MarkdownParser::new(content);
         let rule = MD041;
         let violations = rule.check(&parser, None);
@@ -127,7 +137,12 @@ mod tests {
 
     #[test]
     fn test_blank_lines_before_heading() {
-        let content = "\n\n# Heading\n\nContent";
+        let content = indoc! {"
+
+
+            # Heading
+
+            Content"};
         let parser = MarkdownParser::new(content);
         let rule = MD041;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md043.rs
+++ b/src/lint/rules/md043.rs
@@ -112,6 +112,7 @@ impl Rule for MD043 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_no_config() {
@@ -125,7 +126,10 @@ mod tests {
 
     #[test]
     fn test_correct_structure() {
-        let content = "# Introduction\n## Background\n## Methods";
+        let content = indoc! {"
+            # Introduction
+            ## Background
+            ## Methods"};
         let parser = MarkdownParser::new(content);
         let rule = MD043;
         let config = serde_json::json!({
@@ -152,7 +156,10 @@ mod tests {
 
     #[test]
     fn test_wildcard() {
-        let content = "# Introduction\n## Any Text Here\n## Methods";
+        let content = indoc! {"
+            # Introduction
+            ## Any Text Here
+            ## Methods"};
         let parser = MarkdownParser::new(content);
         let rule = MD043;
         let config = serde_json::json!({

--- a/src/lint/rules/md046.rs
+++ b/src/lint/rules/md046.rs
@@ -107,10 +107,18 @@ impl Rule for MD046 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_consistent_fenced() {
-        let content = "```\ncode1\n```\n\n```\ncode2\n```";
+        let content = indoc! {"
+            ```
+            code1
+            ```
+
+            ```
+            code2
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD046;
         let violations = rule.check(&parser, None);
@@ -131,7 +139,12 @@ mod tests {
 
     #[test]
     fn test_inconsistent() {
-        let content = "```\ncode1\n```\n\n    code2";
+        let content = indoc! {"
+            ```
+            code1
+            ```
+
+                code2"};
         let parser = MarkdownParser::new(content);
         let rule = MD046;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md047.rs
+++ b/src/lint/rules/md047.rs
@@ -93,6 +93,7 @@ impl Rule for MD047 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -103,7 +104,11 @@ mod tests {
 
     #[test]
     fn test_single_newline() {
-        let content = "# Heading\n\nContent\n";
+        let content = indoc! {"
+            # Heading
+
+            Content
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD047;
         let violations = rule.check(&parser, None);
@@ -113,7 +118,10 @@ mod tests {
 
     #[test]
     fn test_no_newline() {
-        let content = "# Heading\n\nContent";
+        let content = indoc! {"
+            # Heading
+
+            Content"};
         let parser = MarkdownParser::new(content);
         let rule = MD047;
         let violations = rule.check(&parser, None);
@@ -123,7 +131,12 @@ mod tests {
 
     #[test]
     fn test_multiple_newlines() {
-        let content = "# Heading\n\nContent\n\n";
+        let content = indoc! {"
+            # Heading
+
+            Content
+
+        "};
         let parser = MarkdownParser::new(content);
         let rule = MD047;
         let violations = rule.check(&parser, None);
@@ -143,12 +156,22 @@ mod tests {
 
     #[test]
     fn test_fix_adds_trailing_newline() {
-        let content = "# Heading\n\nContent";
+        let content = indoc! {"
+            # Heading
+
+            Content"};
         let parser = MarkdownParser::new(content);
         let rule = MD047;
         let violations = rule.check(&parser, None);
         assert_eq!(violations.len(), 1);
         let fixed = apply_fixes(content, &violations);
-        assert_eq!(fixed, "# Heading\n\nContent\n");
+        assert_eq!(
+            fixed,
+            indoc! {"
+                # Heading
+
+                Content
+            "}
+        );
     }
 }

--- a/src/lint/rules/md048.rs
+++ b/src/lint/rules/md048.rs
@@ -111,10 +111,18 @@ impl Rule for MD048 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_consistent_backtick() {
-        let content = "```\ncode1\n```\n\n```\ncode2\n```";
+        let content = indoc! {"
+            ```
+            code1
+            ```
+
+            ```
+            code2
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD048;
         let violations = rule.check(&parser, None);
@@ -124,7 +132,14 @@ mod tests {
 
     #[test]
     fn test_consistent_tilde() {
-        let content = "~~~\ncode1\n~~~\n\n~~~\ncode2\n~~~";
+        let content = indoc! {"
+            ~~~
+            code1
+            ~~~
+
+            ~~~
+            code2
+            ~~~"};
         let parser = MarkdownParser::new(content);
         let rule = MD048;
         let config = serde_json::json!({ "style": "consistent" });
@@ -135,7 +150,14 @@ mod tests {
 
     #[test]
     fn test_inconsistent() {
-        let content = "```\ncode1\n```\n\n~~~\ncode2\n~~~";
+        let content = indoc! {"
+            ```
+            code1
+            ```
+
+            ~~~
+            code2
+            ~~~"};
         let parser = MarkdownParser::new(content);
         let rule = MD048;
         let violations = rule.check(&parser, None);
@@ -145,7 +167,10 @@ mod tests {
 
     #[test]
     fn test_enforced_backtick() {
-        let content = "~~~\ncode\n~~~";
+        let content = indoc! {"
+            ~~~
+            code
+            ~~~"};
         let parser = MarkdownParser::new(content);
         let rule = MD048;
         let config = serde_json::json!({ "style": "backtick" });

--- a/src/lint/rules/md049.rs
+++ b/src/lint/rules/md049.rs
@@ -166,6 +166,7 @@ impl Rule for MD049 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_consistent_asterisk() {
@@ -213,7 +214,23 @@ mod tests {
 
     #[test]
     fn test_code_block_with_underscores() {
-        let content = "Normal text\n\n```sql\nCREATE POLICY territory_contact_access ON contacts\n  FOR SELECT\n  USING (\n    territory_id IN (\n      SELECT territory_id\n      FROM user_territory_assignments\n      WHERE user_id = current_setting('app.current_user_id')::uuid\n        AND (valid_to IS NULL OR valid_to > NOW())\n    )\n  );\n```\n\nMore text";
+        let content = indoc! {"
+            Normal text
+
+            ```sql
+            CREATE POLICY territory_contact_access ON contacts
+              FOR SELECT
+              USING (
+                territory_id IN (
+                  SELECT territory_id
+                  FROM user_territory_assignments
+                  WHERE user_id = current_setting('app.current_user_id')::uuid
+                    AND (valid_to IS NULL OR valid_to > NOW())
+                )
+              );
+            ```
+
+            More text"};
         let parser = MarkdownParser::new(content);
         let rule = MD049;
         let violations = rule.check(&parser, None);
@@ -260,7 +277,10 @@ mod tests {
 
     #[test]
     fn test_typescript_multiplication() {
-        let content = "```typescript\nconst result = value_a * value_b * value_c;\n```";
+        let content = indoc! {"
+            ```typescript
+            const result = value_a * value_b * value_c;
+            ```"};
         let parser = MarkdownParser::new(content);
         let rule = MD049;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md050.rs
+++ b/src/lint/rules/md050.rs
@@ -172,6 +172,7 @@ impl Rule for MD050 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_consistent_asterisk() {
@@ -219,9 +220,14 @@ mod tests {
 
     #[test]
     fn test_code_block_with_underscores() {
-        let content = "Some **bold** text.\n\n\
-            ```txt\n__tests__\n```\n\n\
-            More **bold** text.";
+        let content = indoc! {"
+            Some **bold** text.
+
+            ```txt
+            __tests__
+            ```
+
+            More **bold** text."};
         let parser = MarkdownParser::new(content);
         let rule = MD050;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md051.rs
+++ b/src/lint/rules/md051.rs
@@ -134,10 +134,14 @@ fn heading_to_id(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_valid_fragment() {
-        let content = "# Introduction\n\nSee [intro](#introduction) for more.";
+        let content = indoc! {"
+            # Introduction
+
+            See [intro](#introduction) for more."};
         let parser = MarkdownParser::new(content);
         let rule = MD051;
         let violations = rule.check(&parser, None);
@@ -147,7 +151,10 @@ mod tests {
 
     #[test]
     fn test_invalid_fragment() {
-        let content = "# Introduction\n\nSee [wrong](#nonexistent) for more.";
+        let content = indoc! {"
+            # Introduction
+
+            See [wrong](#nonexistent) for more."};
         let parser = MarkdownParser::new(content);
         let rule = MD051;
         let violations = rule.check(&parser, None);
@@ -158,7 +165,12 @@ mod tests {
 
     #[test]
     fn test_multiple_headings() {
-        let content = "# One\n## Two\n### Three\n\n[Link](#two)";
+        let content = indoc! {"
+            # One
+            ## Two
+            ### Three
+
+            [Link](#two)"};
         let parser = MarkdownParser::new(content);
         let rule = MD051;
         let violations = rule.check(&parser, None);
@@ -168,7 +180,10 @@ mod tests {
 
     #[test]
     fn test_heading_with_spaces() {
-        let content = "# Hello World\n\n[Link](#hello-world)";
+        let content = indoc! {"
+            # Hello World
+
+            [Link](#hello-world)"};
         let parser = MarkdownParser::new(content);
         let rule = MD051;
         let violations = rule.check(&parser, None);
@@ -178,7 +193,10 @@ mod tests {
 
     #[test]
     fn test_external_links_ignored() {
-        let content = "# Section\n\n[External](https://example.com#anything)";
+        let content = indoc! {"
+            # Section
+
+            [External](https://example.com#anything)"};
         let parser = MarkdownParser::new(content);
         let rule = MD051;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md052.rs
+++ b/src/lint/rules/md052.rs
@@ -60,10 +60,14 @@ impl Rule for MD052 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_defined_reference() {
-        let content = "[example]: https://example.com\n\n[Link][example]";
+        let content = indoc! {"
+            [example]: https://example.com
+
+            [Link][example]"};
         let parser = MarkdownParser::new(content);
         let rule = MD052;
         let violations = rule.check(&parser, None);
@@ -84,7 +88,10 @@ mod tests {
 
     #[test]
     fn test_image_reference() {
-        let content = "[img]: image.png\n\n![Alt][img]";
+        let content = indoc! {"
+            [img]: image.png
+
+            ![Alt][img]"};
         let parser = MarkdownParser::new(content);
         let rule = MD052;
         let violations = rule.check(&parser, None);
@@ -105,7 +112,10 @@ mod tests {
 
     #[test]
     fn test_case_insensitive() {
-        let content = "[EXAMPLE]: https://example.com\n\n[Link][example]";
+        let content = indoc! {"
+            [EXAMPLE]: https://example.com
+
+            [Link][example]"};
         let parser = MarkdownParser::new(content);
         let rule = MD052;
         let violations = rule.check(&parser, None);
@@ -128,7 +138,10 @@ mod tests {
 
     #[test]
     fn test_shortcut_reference_defined() {
-        let content = "Here a [reference] is used.\n\n[reference]: https://example.com/";
+        let content = indoc! {"
+            Here a [reference] is used.
+
+            [reference]: https://example.com/"};
         let parser = MarkdownParser::new(content);
         let rule = MD052;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md053.rs
+++ b/src/lint/rules/md053.rs
@@ -73,10 +73,14 @@ impl Rule for MD053 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_used_definition() {
-        let content = "[example]: https://example.com\n\n[Link][example]";
+        let content = indoc! {"
+            [example]: https://example.com
+
+            [Link][example]"};
         let parser = MarkdownParser::new(content);
         let rule = MD053;
         let violations = rule.check(&parser, None);
@@ -86,7 +90,10 @@ mod tests {
 
     #[test]
     fn test_unused_definition() {
-        let content = "[unused]: https://example.com\n\nSome text without links.";
+        let content = indoc! {"
+            [unused]: https://example.com
+
+            Some text without links."};
         let parser = MarkdownParser::new(content);
         let rule = MD053;
         let violations = rule.check(&parser, None);
@@ -97,7 +104,11 @@ mod tests {
 
     #[test]
     fn test_multiple_definitions() {
-        let content = "[used]: https://example.com\n[unused]: https://other.com\n\n[Link][used]";
+        let content = indoc! {"
+            [used]: https://example.com
+            [unused]: https://other.com
+
+            [Link][used]"};
         let parser = MarkdownParser::new(content);
         let rule = MD053;
         let violations = rule.check(&parser, None);
@@ -108,7 +119,10 @@ mod tests {
 
     #[test]
     fn test_image_reference() {
-        let content = "[img]: image.png\n\n![Alt][img]";
+        let content = indoc! {"
+            [img]: image.png
+
+            ![Alt][img]"};
         let parser = MarkdownParser::new(content);
         let rule = MD053;
         let violations = rule.check(&parser, None);
@@ -118,7 +132,11 @@ mod tests {
 
     #[test]
     fn test_all_used() {
-        let content = "[link1]: url1\n[link2]: url2\n\n[A][link1] [B][link2]";
+        let content = indoc! {"
+            [link1]: url1
+            [link2]: url2
+
+            [A][link1] [B][link2]"};
         let parser = MarkdownParser::new(content);
         let rule = MD053;
         let violations = rule.check(&parser, None);
@@ -128,7 +146,12 @@ mod tests {
 
     #[test]
     fn test_shortcut_reference_used() {
-        let content = "Here a [reference] is used.\n\nAnd below it is defined:\n\n[reference]: https://example.com/";
+        let content = indoc! {"
+            Here a [reference] is used.
+
+            And below it is defined:
+
+            [reference]: https://example.com/"};
         let parser = MarkdownParser::new(content);
         let rule = MD053;
         let violations = rule.check(&parser, None);
@@ -138,7 +161,10 @@ mod tests {
 
     #[test]
     fn test_collapsed_reference_used() {
-        let content = "[link]: https://example.com\n\n[Link][]";
+        let content = indoc! {"
+            [link]: https://example.com
+
+            [Link][]"};
         let parser = MarkdownParser::new(content);
         let rule = MD053;
         let violations = rule.check(&parser, None);
@@ -150,7 +176,16 @@ mod tests {
     fn test_shortcut_reference_used_multiple_times() {
         // Regression: [Textual] used twice, definition at end — MD053 must not
         // flag it as unused.
-        let content = "# Title\n\n[Textual] is great.\n\nMore text.\n\n[Textual] again.\n\n[Textual]: https://textual.textualize.io/";
+        let content = indoc! {"
+            # Title
+
+            [Textual] is great.
+
+            More text.
+
+            [Textual] again.
+
+            [Textual]: https://textual.textualize.io/"};
         let parser = MarkdownParser::new(content);
         let rule = MD053;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md054.rs
+++ b/src/lint/rules/md054.rs
@@ -89,6 +89,7 @@ impl Rule for MD054 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_consistent_inline() {
@@ -102,7 +103,11 @@ mod tests {
 
     #[test]
     fn test_consistent_reference() {
-        let content = "[link1]: url1\n[link2]: url2\n\n[Link][link1] and [Another][link2]";
+        let content = indoc! {"
+            [link1]: url1
+            [link2]: url2
+
+            [Link][link1] and [Another][link2]"};
         let parser = MarkdownParser::new(content);
         let rule = MD054;
         let violations = rule.check(&parser, None);
@@ -112,7 +117,10 @@ mod tests {
 
     #[test]
     fn test_inconsistent_style() {
-        let content = "[link1]: url1\n\n[Link](url) and [Ref][link1]";
+        let content = indoc! {"
+            [link1]: url1
+
+            [Link](url) and [Ref][link1]"};
         let parser = MarkdownParser::new(content);
         let rule = MD054;
         let config = serde_json::json!({ "style": "consistent" });
@@ -123,7 +131,10 @@ mod tests {
 
     #[test]
     fn test_enforced_inline() {
-        let content = "[link]: url\n\n[Link][link]";
+        let content = indoc! {"
+            [link]: url
+
+            [Link][link]"};
         let parser = MarkdownParser::new(content);
         let rule = MD054;
         let config = serde_json::json!({ "style": "inline" });

--- a/src/lint/rules/md055.rs
+++ b/src/lint/rules/md055.rs
@@ -175,10 +175,14 @@ impl Rule for MD055 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_consistent_with_pipes() {
-        let content = "| Col1 | Col2 |\n|------|------|\n| A    | B    |";
+        let content = indoc! {"
+            | Col1 | Col2 |
+            |------|------|
+            | A    | B    |"};
         let parser = MarkdownParser::new(content);
         let rule = MD055;
         let violations = rule.check(&parser, None);
@@ -188,7 +192,10 @@ mod tests {
 
     #[test]
     fn test_consistent_without_pipes() {
-        let content = "Col1 | Col2\n-----|-----\nA    | B";
+        let content = indoc! {"
+            Col1 | Col2
+            -----|-----
+            A    | B"};
         let parser = MarkdownParser::new(content);
         let rule = MD055;
         let config = serde_json::json!({ "style": "consistent" });
@@ -199,7 +206,10 @@ mod tests {
 
     #[test]
     fn test_inconsistent_pipes() {
-        let content = "| Col1 | Col2 |\n|------|------|\nA    | B";
+        let content = indoc! {"
+            | Col1 | Col2 |
+            |------|------|
+            A    | B"};
         let parser = MarkdownParser::new(content);
         let rule = MD055;
         let violations = rule.check(&parser, None);
@@ -210,7 +220,10 @@ mod tests {
 
     #[test]
     fn test_enforced_leading_and_trailing() {
-        let content = "Col1 | Col2\n-----|-----\nA | B";
+        let content = indoc! {"
+            Col1 | Col2
+            -----|-----
+            A | B"};
         let parser = MarkdownParser::new(content);
         let rule = MD055;
         let config = serde_json::json!({ "style": "leading_and_trailing" });
@@ -222,7 +235,10 @@ mod tests {
 
     #[test]
     fn test_simple_table() {
-        let content = "| Header |\n| ------ |\n| Cell   |";
+        let content = indoc! {"
+            | Header |
+            | ------ |
+            | Cell   |"};
         let parser = MarkdownParser::new(content);
         let rule = MD055;
         let violations = rule.check(&parser, None);
@@ -233,7 +249,10 @@ mod tests {
     #[test]
     fn test_pipe_only_in_inline_code_span_ignored() {
         // https://github.com/swanysimon/mdlint/issues/65
-        let content = "# Example\n\nThis is a line with an `a | b` inline code span.";
+        let content = indoc! {"
+            # Example
+
+            This is a line with an `a | b` inline code span."};
         let parser = MarkdownParser::new(content);
         let rule = MD055;
         let violations = rule.check(&parser, None);
@@ -245,7 +264,10 @@ mod tests {
     fn test_real_table_with_code_span_pipe_still_flagged() {
         // A genuine table row whose leading/trailing pipes are real, even
         // though it also contains a code span with an internal pipe.
-        let content = "Col1 | `a|b`\n-----|-----\nA | B";
+        let content = indoc! {"
+            Col1 | `a|b`
+            -----|-----
+            A | B"};
         let parser = MarkdownParser::new(content);
         let rule = MD055;
         let config = serde_json::json!({ "style": "leading_and_trailing" });

--- a/src/lint/rules/md056.rs
+++ b/src/lint/rules/md056.rs
@@ -136,10 +136,15 @@ fn is_separator_line(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_valid_table() {
-        let content = "| Col1 | Col2 | Col3 |\n|------|------|------|\n| A    | B    | C    |\n| D    | E    | F    |";
+        let content = indoc! {"
+            | Col1 | Col2 | Col3 |
+            |------|------|------|
+            | A    | B    | C    |
+            | D    | E    | F    |"};
         let parser = MarkdownParser::new(content);
         let rule = MD056;
         let violations = rule.check(&parser, None);
@@ -149,7 +154,10 @@ mod tests {
 
     #[test]
     fn test_mismatched_columns() {
-        let content = "| Col1 | Col2 |\n|------|------|\n| A    | B    | C    |";
+        let content = indoc! {"
+            | Col1 | Col2 |
+            |------|------|
+            | A    | B    | C    |"};
         let parser = MarkdownParser::new(content);
         let rule = MD056;
         let violations = rule.check(&parser, None);
@@ -159,7 +167,10 @@ mod tests {
 
     #[test]
     fn test_separator_mismatch() {
-        let content = "| Col1 | Col2 | Col3 |\n|------|------|\n| A    | B    | C    |";
+        let content = indoc! {"
+            | Col1 | Col2 | Col3 |
+            |------|------|
+            | A    | B    | C    |"};
         let parser = MarkdownParser::new(content);
         let rule = MD056;
         let violations = rule.check(&parser, None);
@@ -169,7 +180,12 @@ mod tests {
 
     #[test]
     fn test_multiple_rows() {
-        let content = "| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 | 5 |\n| 6 | 7 |";
+        let content = indoc! {"
+            | A | B |
+            |---|---|
+            | 1 | 2 |
+            | 3 | 4 | 5 |
+            | 6 | 7 |"};
         let parser = MarkdownParser::new(content);
         let rule = MD056;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md058.rs
+++ b/src/lint/rules/md058.rs
@@ -79,10 +79,18 @@ fn is_separator_line(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_table_with_blank_lines() {
-        let content = "Text before\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nText after";
+        let content = indoc! {"
+            Text before
+
+            | A | B |
+            |---|---|
+            | 1 | 2 |
+
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD058;
         let violations = rule.check(&parser, None);
@@ -92,7 +100,13 @@ mod tests {
 
     #[test]
     fn test_table_without_blank_before() {
-        let content = "Text before\n| A | B |\n|---|---|\n| 1 | 2 |\n\nText after";
+        let content = indoc! {"
+            Text before
+            | A | B |
+            |---|---|
+            | 1 | 2 |
+
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD058;
         let violations = rule.check(&parser, None);
@@ -102,7 +116,13 @@ mod tests {
 
     #[test]
     fn test_table_without_blank_after() {
-        let content = "Text before\n\n| A | B |\n|---|---|\n| 1 | 2 |\nText after";
+        let content = indoc! {"
+            Text before
+
+            | A | B |
+            |---|---|
+            | 1 | 2 |
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD058;
         let violations = rule.check(&parser, None);
@@ -113,7 +133,12 @@ mod tests {
 
     #[test]
     fn test_table_without_any_blank_lines() {
-        let content = "Text before\n| A | B |\n|---|---|\n| 1 | 2 |\nText after";
+        let content = indoc! {"
+            Text before
+            | A | B |
+            |---|---|
+            | 1 | 2 |
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD058;
         let violations = rule.check(&parser, None);
@@ -124,7 +149,12 @@ mod tests {
 
     #[test]
     fn test_table_at_start() {
-        let content = "| A | B |\n|---|---|\n| 1 | 2 |\n\nText after";
+        let content = indoc! {"
+            | A | B |
+            |---|---|
+            | 1 | 2 |
+
+            Text after"};
         let parser = MarkdownParser::new(content);
         let rule = MD058;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md060.rs
+++ b/src/lint/rules/md060.rs
@@ -124,10 +124,14 @@ fn parse_alignments(line: &str) -> Vec<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_consistent_alignment() {
-        let content = "| A | B |\n|---|---|\n| 1 | 2 |";
+        let content = indoc! {"
+            | A | B |
+            |---|---|
+            | 1 | 2 |"};
         let parser = MarkdownParser::new(content);
         let rule = MD060;
         let violations = rule.check(&parser, None);
@@ -137,7 +141,10 @@ mod tests {
 
     #[test]
     fn test_mixed_alignment() {
-        let content = "| A | B | C |\n|:--|--:|:--:|\n| 1 | 2 | 3 |";
+        let content = indoc! {"
+            | A | B | C |
+            |:--|--:|:--:|
+            | 1 | 2 | 3 |"};
         let parser = MarkdownParser::new(content);
         let rule = MD060;
         let violations = rule.check(&parser, None);
@@ -148,7 +155,10 @@ mod tests {
 
     #[test]
     fn test_enforced_left() {
-        let content = "| A | B |\n|:--|--:|\n| 1 | 2 |";
+        let content = indoc! {"
+            | A | B |
+            |:--|--:|
+            | 1 | 2 |"};
         let parser = MarkdownParser::new(content);
         let rule = MD060;
         let config = serde_json::json!({ "style": "left" });
@@ -159,7 +169,10 @@ mod tests {
 
     #[test]
     fn test_enforced_default() {
-        let content = "| A | B |\n|---|:--|\n| 1 | 2 |";
+        let content = indoc! {"
+            | A | B |
+            |---|:--|
+            | 1 | 2 |"};
         let parser = MarkdownParser::new(content);
         let rule = MD060;
         let config = serde_json::json!({ "style": "default" });

--- a/src/markdown/front_matter.rs
+++ b/src/markdown/front_matter.rs
@@ -72,10 +72,16 @@ pub fn strip_front_matter(content: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_detect_yaml_front_matter() {
-        let content = "---\ntitle: Test\nauthor: John\n---\n# Heading";
+        let content = indoc! {"
+            ---
+            title: Test
+            author: John
+            ---
+            # Heading"};
         let fm = detect_front_matter(content).unwrap();
 
         assert_eq!(fm.matter_type, FrontMatterType::Yaml);
@@ -85,7 +91,12 @@ mod tests {
 
     #[test]
     fn test_detect_toml_front_matter() {
-        let content = "+++\ntitle = \"Test\"\nauthor = \"John\"\n+++\n# Heading";
+        let content = indoc! {"
+            +++
+            title = \"Test\"
+            author = \"John\"
+            +++
+            # Heading"};
         let fm = detect_front_matter(content).unwrap();
 
         assert_eq!(fm.matter_type, FrontMatterType::Toml);
@@ -101,13 +112,21 @@ mod tests {
 
     #[test]
     fn test_incomplete_front_matter() {
-        let content = "---\ntitle: Test\n# Heading";
+        let content = indoc! {"
+            ---
+            title: Test
+            # Heading"};
         assert!(detect_front_matter(content).is_none());
     }
 
     #[test]
     fn test_strip_front_matter() {
-        let content = "---\ntitle: Test\n---\n# Heading\nContent";
+        let content = indoc! {"
+            ---
+            title: Test
+            ---
+            # Heading
+            Content"};
         let stripped = strip_front_matter(content);
 
         assert_eq!(stripped, "# Heading\nContent");

--- a/src/markdown/parser.rs
+++ b/src/markdown/parser.rs
@@ -285,10 +285,14 @@ fn build_ref_def_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
     fn test_basic_parsing() {
-        let content = "# Heading\n\nSome **bold** text.";
+        let content = indoc! {"
+            # Heading
+
+            Some **bold** text."};
         let parser = MarkdownParser::new(content);
 
         assert_eq!(parser.content(), content);
@@ -297,7 +301,10 @@ mod tests {
 
     #[test]
     fn test_get_line() {
-        let content = "Line 1\nLine 2\nLine 3";
+        let content = indoc! {"
+            Line 1
+            Line 2
+            Line 3"};
         let parser = MarkdownParser::new(content);
 
         assert_eq!(parser.get_line(1), Some("Line 1"));
@@ -309,7 +316,10 @@ mod tests {
 
     #[test]
     fn test_offset_to_line() {
-        let content = "Line 1\nLine 2\nLine 3";
+        let content = indoc! {"
+            Line 1
+            Line 2
+            Line 3"};
         let parser = MarkdownParser::new(content);
 
         assert_eq!(parser.offset_to_line(0), 1);
@@ -320,7 +330,10 @@ mod tests {
 
     #[test]
     fn test_offset_to_position() {
-        let content = "Line 1\nLine 2\nLine 3";
+        let content = indoc! {"
+            Line 1
+            Line 2
+            Line 3"};
         let parser = MarkdownParser::new(content);
 
         assert_eq!(parser.offset_to_position(0), (1, 1));
@@ -340,7 +353,10 @@ mod tests {
 
     #[test]
     fn test_parse_with_offsets() {
-        let content = "# Heading\n\nParagraph";
+        let content = indoc! {"
+            # Heading
+
+            Paragraph"};
         let parser = MarkdownParser::new(content);
 
         let events: Vec<_> = parser.parse_with_offsets().collect();
@@ -349,7 +365,14 @@ mod tests {
 
     #[test]
     fn test_event_type_checks() {
-        let content = "# Heading\n\n```rust\ncode\n```\n\n- item";
+        let content = indoc! {"
+            # Heading
+
+            ```rust
+            code
+            ```
+
+            - item"};
         let parser = MarkdownParser::new(content);
 
         let events: Vec<_> = parser.parse().collect();
@@ -365,7 +388,15 @@ mod tests {
 
     #[test]
     fn test_code_line_numbers_fenced() {
-        let content = "Normal text\n\n```sql\nSELECT * FROM table_name\nWHERE user_id = 123\n```\n\nMore text";
+        let content = indoc! {"
+            Normal text
+
+            ```sql
+            SELECT * FROM table_name
+            WHERE user_id = 123
+            ```
+
+            More text"};
         let parser = MarkdownParser::new(content);
         let code_lines = parser.get_code_line_numbers();
 
@@ -408,8 +439,16 @@ mod tests {
 
     #[test]
     fn test_code_line_numbers_mixed() {
-        let content =
-            "Normal text\n\nText with `inline_code` here\n\n```\nCode block\n```\n\nFinal text";
+        let content = indoc! {"
+            Normal text
+
+            Text with `inline_code` here
+
+            ```
+            Code block
+            ```
+
+            Final text"};
         let parser = MarkdownParser::new(content);
         let code_lines = parser.get_code_line_numbers();
 
@@ -439,7 +478,10 @@ mod tests {
     #[test]
     fn test_build_line_offsets() {
         // LF line endings
-        let offsets = build_line_offsets("abc\ndef\nghi");
+        let offsets = build_line_offsets(indoc! {"
+            abc
+            def
+            ghi"});
         assert_eq!(offsets, vec![0, 4, 8]);
 
         // CRLF line endings
@@ -472,7 +514,12 @@ mod tests {
 
     #[test]
     fn test_ref_def_line_numbers() {
-        let content = "Text\n\n[foo]: https://example.com\n\nMore text";
+        let content = indoc! {"
+            Text
+
+            [foo]: https://example.com
+
+            More text"};
         let parser = MarkdownParser::new(content);
         let ref_def_lines = parser.get_ref_def_line_numbers();
 

--- a/src/migrate/markdownlint_cli2/cli2.rs
+++ b/src/migrate/markdownlint_cli2/cli2.rs
@@ -153,11 +153,16 @@ fn document_to_source_as_wrapper(mut document: HashMap<String, Value>) -> Cli2So
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
     use std::path::PathBuf;
 
     #[test]
     fn strips_line_and_block_comments() {
-        let input = "{\n  // a comment\n  \"a\": 1, /* inline */ \"b\": \"// not a comment\"\n}";
+        let input = indoc! {"
+            {
+              // a comment
+              \"a\": 1, /* inline */ \"b\": \"// not a comment\"
+            }"};
         let stripped = strip_jsonc_comments(input);
         let value: Value = serde_json::from_str(&stripped).unwrap();
         assert_eq!(value["a"], 1);
@@ -189,7 +194,14 @@ mod tests {
 
     #[test]
     fn parses_cli2_wrapper_yaml() {
-        let content = "config:\n  MD013:\n    line_length: 100\nignores:\n  - dist/**\nfix: true\n";
+        let content = indoc! {"
+            config:
+              MD013:
+                line_length: 100
+            ignores:
+              - dist/**
+            fix: true
+        "};
         let source = parse_yaml(content, &PathBuf::from(".markdownlint-cli2.yaml")).unwrap();
         assert_eq!(source.ignores, Some(vec!["dist/**".to_string()]));
         assert_eq!(source.fix, Some(true));

--- a/src/server/convert.rs
+++ b/src/server/convert.rs
@@ -128,6 +128,7 @@ pub fn uri_to_path(uri: &Uri) -> Option<PathBuf> {
 mod tests {
     use super::*;
     use crate::types::Violation;
+    use indoc::indoc;
     use std::str::FromStr;
 
     fn make_violation(line: usize, column: Option<usize>) -> Violation {
@@ -143,7 +144,14 @@ mod tests {
     #[test]
     fn test_coord_no_column() {
         let v = make_violation(3, None);
-        let diag = violation_to_diagnostic(&v, "line1\nline2\nline3\n");
+        let diag = violation_to_diagnostic(
+            &v,
+            indoc! {"
+                line1
+                line2
+                line3
+            "},
+        );
         assert_eq!(diag.range.start.line, 2);
         assert_eq!(diag.range.start.character, 0);
     }

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -1,3 +1,4 @@
+use indoc::indoc;
 use mdlint::formatter;
 use std::fs;
 use std::process::{Command, Stdio};
@@ -36,19 +37,51 @@ fn mdlint_bin() -> std::path::PathBuf {
 #[test]
 fn setext_headings_become_atx() {
     assert_formats_to(
-        "Title\n=====\n\nSection\n-------\n",
-        "# Title\n\n## Section\n",
+        indoc! {"
+            Title
+            =====
+
+            Section
+            -------
+        "},
+        indoc! {"
+            # Title
+
+            ## Section
+        "},
     );
 }
 
 #[test]
 fn closed_atx_headings_stripped() {
-    assert_formats_to("## Heading ##\n\n### Sub ###\n", "## Heading\n\n### Sub\n");
+    assert_formats_to(
+        indoc! {"
+            ## Heading ##
+
+            ### Sub ###
+        "},
+        indoc! {"
+            ## Heading
+
+            ### Sub
+        "},
+    );
 }
 
 #[test]
 fn extra_spaces_after_hash_collapsed() {
-    assert_formats_to("#  Too many\n\n###   Lots\n", "# Too many\n\n### Lots\n");
+    assert_formats_to(
+        indoc! {"
+            #  Too many
+
+            ###   Lots
+        "},
+        indoc! {"
+            # Too many
+
+            ### Lots
+        "},
+    );
 }
 
 #[test]
@@ -57,18 +90,51 @@ fn asterisk_and_plus_list_markers_become_dash() {
     // HTML comment separator is inserted so they don't merge into a single
     // list (and become loose) on the second format pass.
     assert_formats_to(
-        "* Alpha\n* Beta\n\n+ Gamma\n+ Delta\n",
-        "- Alpha\n- Beta\n\n<!---->\n\n- Gamma\n- Delta\n",
+        indoc! {"
+            * Alpha
+            * Beta
+
+            + Gamma
+            + Delta
+        "},
+        indoc! {"
+            - Alpha
+            - Beta
+
+            <!---->
+
+            - Gamma
+            - Delta
+        "},
     );
 }
 
 #[test]
 fn tilde_code_fences_become_backtick() {
     assert_formats_to(
-        "~~~rust\nfn main() {}\n~~~\n",
-        "```rust\nfn main() {}\n```\n",
+        indoc! {"
+            ~~~rust
+            fn main() {}
+            ~~~
+        "},
+        indoc! {"
+            ```rust
+            fn main() {}
+            ```
+        "},
     );
-    assert_formats_to("~~~\nplain\n~~~\n", "```\nplain\n```\n");
+    assert_formats_to(
+        indoc! {"
+            ~~~
+            plain
+            ~~~
+        "},
+        indoc! {"
+            ```
+            plain
+            ```
+        "},
+    );
 }
 
 #[test]
@@ -86,7 +152,20 @@ fn horizontal_rules_normalised_to_dashes() {
 
 #[test]
 fn multiple_blank_lines_collapsed() {
-    assert_formats_to("First.\n\n\n\nSecond.\n", "First.\n\nSecond.\n");
+    assert_formats_to(
+        indoc! {"
+            First.
+
+
+
+            Second.
+        "},
+        indoc! {"
+            First.
+
+            Second.
+        "},
+    );
 }
 
 #[test]
@@ -106,8 +185,24 @@ fn trailing_whitespace_removed() {
 #[test]
 fn trailing_newline_normalised() {
     assert!(formatter::format("text").ends_with('\n'));
-    assert!(formatter::format("text\n\n\n").ends_with('\n'));
-    assert_eq!(formatter::format("text\n\n\n").matches('\n').count(), 1);
+    assert!(
+        formatter::format(indoc! {"
+            text
+
+
+        "})
+        .ends_with('\n')
+    );
+    assert_eq!(
+        formatter::format(indoc! {"
+            text
+
+
+        "})
+        .matches('\n')
+        .count(),
+        1
+    );
 }
 
 #[test]
@@ -121,8 +216,18 @@ fn empty_input_produces_empty_output() {
 #[test]
 fn nested_lists_preserved() {
     assert_formats_to(
-        "- Top\n  - Nested\n    - Deep\n- Back\n",
-        "- Top\n  - Nested\n    - Deep\n- Back\n",
+        indoc! {"
+            - Top
+              - Nested
+                - Deep
+            - Back
+        "},
+        indoc! {"
+            - Top
+              - Nested
+                - Deep
+            - Back
+        "},
     );
 }
 
@@ -134,23 +239,52 @@ fn nested_ordered_list_under_bullet_item_stays_tight() {
     // lines around it. This canonical form must pass `mdlint check` (MD032)
     // cleanly — see the matching MD032 tests in src/lint/rules/md032.rs.
     assert_formats_to(
-        "# Example\n\n- First item:\n\n  1. One\n  2. Two\n\n- Second item\n",
-        "# Example\n\n- First item:\n  1. One\n  2. Two\n- Second item\n",
+        indoc! {"
+            # Example
+
+            - First item:
+
+              1. One
+              2. Two
+
+            - Second item
+        "},
+        indoc! {"
+            # Example
+
+            - First item:
+              1. One
+              2. Two
+            - Second item
+        "},
     );
 }
 
 #[test]
 fn ordered_list_preserved() {
     assert_formats_to(
-        "1. First\n2. Second\n3. Third\n",
-        "1. First\n2. Second\n3. Third\n",
+        indoc! {"
+            1. First
+            2. Second
+            3. Third
+        "},
+        indoc! {"
+            1. First
+            2. Second
+            3. Third
+        "},
     );
 }
 
 #[test]
 fn code_block_content_preserved_verbatim() {
     // Tabs and unusual indentation inside code blocks must survive unchanged.
-    let input = "```\n\tindented with tab\n    four spaces\n```\n";
+    let input = indoc! {"
+        ```
+        \tindented with tab
+            four spaces
+        ```
+    "};
     assert_formats_to(input, input);
 }
 
@@ -173,8 +307,16 @@ fn link_and_image_preserved() {
 #[test]
 fn blockquote_preserved() {
     assert_formats_to(
-        "> quoted\n>\n> second para\n",
-        "> quoted\n>\n> second para\n",
+        indoc! {"
+            > quoted
+            >
+            > second para
+        "},
+        indoc! {"
+            > quoted
+            >
+            > second para
+        "},
     );
 }
 
@@ -182,14 +324,26 @@ fn blockquote_preserved() {
 fn gfm_table_canonicalised() {
     // Input without leading/trailing pipes → output with them
     assert_formats_to(
-        "A | B\n--- | ---\n1 | 2\n",
-        "| A | B |\n| --- | --- |\n| 1 | 2 |\n",
+        indoc! {"
+            A | B
+            --- | ---
+            1 | 2
+        "},
+        indoc! {"
+            | A | B |
+            | --- | --- |
+            | 1 | 2 |
+        "},
     );
 }
 
 #[test]
 fn gfm_table_already_canonical_unchanged() {
-    let canonical = "| A | B |\n| --- | --- |\n| 1 | 2 |\n";
+    let canonical = indoc! {"
+        | A | B |
+        | --- | --- |
+        | 1 | 2 |
+    "};
     assert_formats_to(canonical, canonical);
 }
 
@@ -198,8 +352,14 @@ fn list_item_continuation_indented() {
     // A soft-wrapped list item must keep its continuation indented so the
     // linter does not mistake it for a paragraph outside the list.
     assert_formats_to(
-        "- First line\n  continuation here\n",
-        "- First line\n  continuation here\n",
+        indoc! {"
+            - First line
+              continuation here
+        "},
+        indoc! {"
+            - First line
+              continuation here
+        "},
     );
 }
 
@@ -207,12 +367,29 @@ fn list_item_continuation_indented() {
 
 #[test]
 fn idempotent_on_mixed_document() {
-    let input = "# Title\n\nIntro paragraph.\n\n## Section\n\n\
-                 - Item one\n- Item two\n  - Nested\n\n\
-                 ```rust\nfn main() {}\n```\n\n\
-                 | Col A | Col B |\n| ----- | ----- |\n| val   | val   |\n\n\
-                 > A blockquote\n\n\
-                 Final paragraph.\n";
+    let input = indoc! {"
+        # Title
+
+        Intro paragraph.
+
+        ## Section
+
+        - Item one
+        - Item two
+          - Nested
+
+        ```rust
+        fn main() {}
+        ```
+
+        | Col A | Col B |
+        | ----- | ----- |
+        | val   | val   |
+
+        > A blockquote
+
+        Final paragraph.
+    "};
     let once = formatter::format(input);
     let twice = formatter::format(&once);
     assert_eq!(once, twice, "formatter is not idempotent on mixed document");
@@ -225,7 +402,12 @@ fn format_check_does_not_modify_file() {
     // `format --check` must never write to disk even when changes are needed.
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("doc.md");
-    let original = "Heading\n=======\n\n* item\n";
+    let original = indoc! {"
+        Heading
+        =======
+
+        * item
+    "};
     fs::write(&file, original).unwrap();
 
     Command::new(mdlint_bin())
@@ -243,7 +425,15 @@ fn format_check_does_not_modify_file() {
 fn format_check_exits_0_when_already_formatted() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("clean.md");
-    fs::write(&file, "# Heading\n\nParagraph.\n").unwrap();
+    fs::write(
+        &file,
+        indoc! {"
+            # Heading
+
+            Paragraph.
+        "},
+    )
+    .unwrap();
 
     let status = Command::new(mdlint_bin())
         .args(["format", "--check", file.to_str().unwrap()])
@@ -262,7 +452,16 @@ fn format_check_exits_0_when_already_formatted() {
 fn format_check_exits_1_when_file_needs_formatting() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("dirty.md");
-    fs::write(&file, "Heading\n=======\n\nParagraph.\n").unwrap();
+    fs::write(
+        &file,
+        indoc! {"
+            Heading
+            =======
+
+            Paragraph.
+        "},
+    )
+    .unwrap();
 
     let status = Command::new(mdlint_bin())
         .args(["format", "--check", file.to_str().unwrap()])
@@ -282,7 +481,16 @@ fn format_check_exits_1_when_file_needs_formatting() {
 fn format_rewrites_file_in_place() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("doc.md");
-    fs::write(&file, "Heading\n=======\n\n* item\n").unwrap();
+    fs::write(
+        &file,
+        indoc! {"
+            Heading
+            =======
+
+            * item
+        "},
+    )
+    .unwrap();
 
     let status = Command::new(mdlint_bin())
         .args(["format", file.to_str().unwrap()])
@@ -293,7 +501,14 @@ fn format_rewrites_file_in_place() {
 
     assert!(status.success());
     let result = fs::read_to_string(&file).unwrap();
-    assert_eq!(result, "# Heading\n\n- item\n");
+    assert_eq!(
+        result,
+        indoc! {"
+            # Heading
+
+            - item
+        "}
+    );
 }
 
 // ── `mdlint check` CLI ───────────────────────────────────────────────────────
@@ -304,7 +519,14 @@ fn check_without_fix_does_not_modify_file() {
     // We supply an explicit config because the default has `fix = true`.
     let dir = TempDir::new().unwrap();
     let config = dir.path().join("mdlint.toml");
-    fs::write(&config, "default_enabled = true\nfix = false\n").unwrap();
+    fs::write(
+        &config,
+        indoc! {"
+            default_enabled = true
+            fix = false
+        "},
+    )
+    .unwrap();
     let file = dir.path().join("doc.md");
     let content = "# Heading\n\nTrailing spaces.   \n";
     fs::write(&file, content).unwrap();
@@ -350,7 +572,12 @@ fn check_with_fix_corrects_violations_and_exits_1() {
     );
     let after = fs::read_to_string(&file).unwrap();
     assert_eq!(
-        after, "# Heading\n\nTrailing spaces.\n",
+        after,
+        indoc! {"
+            # Heading
+
+            Trailing spaces.
+        "},
         "trailing spaces should be removed by --fix"
     );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,3 +1,4 @@
+use indoc::indoc;
 use mdlint::config::{Config, RuleConfig};
 use mdlint::fix::Fixer;
 use mdlint::formatter;
@@ -83,7 +84,15 @@ fn check_fix_removes_trailing_spaces() {
     let result = Fixer::new()
         .apply_fixes_to_content(content, &fixes)
         .unwrap();
-    assert_eq!(result, "# Heading\n\nSome text\nMore text\n");
+    assert_eq!(
+        result,
+        indoc! {"
+            # Heading
+
+            Some text
+            More text
+        "}
+    );
 }
 
 #[test]
@@ -99,7 +108,11 @@ fn check_detects_hard_tabs() {
 
 #[test]
 fn check_fix_replaces_hard_tabs() {
-    let content = "# Heading\n\n\tTabbed line\n";
+    let content = indoc! {"
+        # Heading
+
+        \tTabbed line
+    "};
     let engine = all_rules_engine();
     let violations = engine.lint_content(content).unwrap();
     let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -118,7 +131,16 @@ fn format_output_for_nested_list_passes_check() {
     // (intended, canonical behavior), but MD032 then misjudged the nested,
     // differently-marked sub-list as a set of separate top-level lists,
     // reporting spurious violations on the formatter's own output.
-    let content = "# Example\n\n- First item:\n\n  1. One\n  2. Two\n\n- Second item\n";
+    let content = indoc! {"
+        # Example
+
+        - First item:
+
+          1. One
+          2. Two
+
+        - Second item
+    "};
     let formatted = formatter::format(content);
     let engine = all_rules_engine();
     let violations = engine.lint_content(&formatted).unwrap();
@@ -159,7 +181,13 @@ fn check_clean_file_has_no_violations() {
 fn select_restricts_check_to_named_rule() {
     // Line has both a heading-level skip (MD001) and a hard tab (MD010); --select MD001
     // should report only MD001.
-    let content = "# Heading\n\n### Skipped level\n\n\tTabbed line\n";
+    let content = indoc! {"
+        # Heading
+
+        ### Skipped level
+
+        \tTabbed line
+    "};
     let config = Config::default().apply_rule_filters(&["MD001".to_owned()], &[]);
     let violations = LintEngine::new(config).lint_content(content).unwrap();
     assert!(violations.iter().any(|v| v.rule == "MD001"));
@@ -168,7 +196,13 @@ fn select_restricts_check_to_named_rule() {
 
 #[test]
 fn ignore_excludes_named_rule_only() {
-    let content = "# Heading\n\n### Skipped level\n\n\tTabbed line\n";
+    let content = indoc! {"
+        # Heading
+
+        ### Skipped level
+
+        \tTabbed line
+    "};
     let config = Config::default().apply_rule_filters(&[], &["MD010".to_owned()]);
     let violations = LintEngine::new(config).lint_content(content).unwrap();
     assert!(violations.iter().any(|v| v.rule == "MD001"));

--- a/tests/lsp.rs
+++ b/tests/lsp.rs
@@ -1,3 +1,4 @@
+use indoc::indoc;
 use lsp_server::{Connection, Message, Notification, Request, RequestId, Response};
 use lsp_types::{
     CodeActionOrCommand, InitializeResult, NumberOrString, PublishDiagnosticsParams, TextEdit,
@@ -92,7 +93,10 @@ fn lsp_full_lifecycle() {
     initialize(&client_conn);
 
     // MD022 violation: no blank line between headings.
-    let content = "# Title\n## Section\n";
+    let content = indoc! {"
+        # Title
+        ## Section
+    "};
 
     // 2. didOpen → publishDiagnostics
     send_notification(


### PR DESCRIPTION
It can be really hard to visually intuit what exactly we are testing. This change makes that much more obvious by using the indoc package to allow for auto-dedented strings