### PR TITLE
Use more details in test assertions

### DIFF
--- a/src/lint/rules/md001.rs
+++ b/src/lint/rules/md001.rs
@@ -69,6 +69,7 @@ fn heading_level_to_u8(level: HeadingLevel) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -92,9 +93,10 @@ mod tests {
         let rule = MD001;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 2);
-        assert!(violations[0].message.contains("h1 to h3"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD001 Heading level skipped from h1 to h3"]
+        );
     }
 
     #[test]
@@ -108,9 +110,13 @@ mod tests {
         let rule = MD001;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2);
-        assert_eq!(violations[0].line, 2);
-        assert_eq!(violations[1].line, 4);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:2:1: MD001 Heading level skipped from h1 to h4",
+                "test.md:4:1: MD001 Heading level skipped from h2 to h5",
+            ]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md003.rs
+++ b/src/lint/rules/md003.rs
@@ -127,6 +127,7 @@ impl Rule for MD003 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -152,7 +153,10 @@ mod tests {
         let rule = MD003;
         let violations = rule.check(&parser, None);
 
-        assert!(!violations.is_empty());
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD003 Heading style should be Atx but found AtxClosed"]
+        );
     }
 
     #[test]
@@ -163,7 +167,10 @@ mod tests {
         let config = serde_json::json!({ "style": "atx" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1); // Second heading has closing #
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD003 Heading style should be Atx but found AtxClosed"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md004.rs
+++ b/src/lint/rules/md004.rs
@@ -133,6 +133,7 @@ impl Rule for MD004 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -166,7 +167,15 @@ mod tests {
         let rule = MD004;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2); // Second and third items differ from first
+        // mdlint enforces `dash` by default rather than first-marker-wins, so
+        // the asterisk and plus are flagged and the dash is accepted.
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:1: MD004 List marker style should be Dash",
+                "test.md:2:1: MD004 List marker style should be Dash",
+            ]
+        );
     }
 
     #[test]
@@ -177,7 +186,10 @@ mod tests {
         let config = serde_json::json!({ "style": "dash" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1); // First item uses asterisk
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD004 List marker style should be Dash"]
+        );
     }
 
     #[test]
@@ -268,7 +280,13 @@ mod tests {
         let rule = MD004;
         let config = serde_json::json!({ "style": "dash" });
         let violations = rule.check(&parser, Some(&config));
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:1: MD004 List marker style should be Dash",
+                "test.md:2:1: MD004 List marker style should be Dash",
+            ]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(
             fixed,
@@ -296,8 +314,12 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // Both non-dash markers violate the default "dash" style
-        assert_eq!(violations.len(), 2);
-        assert_eq!(violations[0].line, 1); // Line with "* List item 1"
-        assert_eq!(violations[1].line, 8); // Line with "+ List item 2"
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:1: MD004 List marker style should be Dash",
+                "test.md:8:1: MD004 List marker style should be Dash",
+            ]
+        );
     }
 }

--- a/src/lint/rules/md005.rs
+++ b/src/lint/rules/md005.rs
@@ -92,6 +92,7 @@ impl Rule for MD005 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -119,7 +120,10 @@ mod tests {
         let rule = MD005;
         let violations = rule.check(&parser, None);
 
-        assert!(!violations.is_empty());
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD005 List item indentation mismatch: expected 0 spaces, found 1"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md007.rs
+++ b/src/lint/rules/md007.rs
@@ -92,6 +92,7 @@ impl Rule for MD007 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -116,7 +117,10 @@ mod tests {
         let rule = MD007;
         let violations = rule.check(&parser, None);
 
-        assert!(!violations.is_empty());
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD007 Unordered list indentation should be 2 spaces (found 3)"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md009.rs
+++ b/src/lint/rules/md009.rs
@@ -71,6 +71,7 @@ impl Rule for MD009 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -100,9 +101,10 @@ mod tests {
         let rule = MD009;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1); // Line 3 has 3 spaces, Line 1 has 2 (allowed for br)
-        assert_eq!(violations[0].line, 3);
-        assert_eq!(violations[0].column, Some(7));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:3:7: MD009 Trailing spaces (3 spaces)"]
+        );
     }
 
     #[test]
@@ -113,8 +115,10 @@ mod tests {
         let config = serde_json::json!({ "strict": true });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:7: MD009 Trailing spaces (2 spaces)"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md010.rs
+++ b/src/lint/rules/md010.rs
@@ -88,6 +88,7 @@ impl Rule for MD010 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -120,9 +121,10 @@ mod tests {
         let rule = MD010;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 2);
-        assert_eq!(violations[0].column, Some(1));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD010 Hard tabs found"]
+        );
     }
 
     #[test]
@@ -137,7 +139,10 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // By default, code_blocks is true, so tabs in code blocks are violations
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:3:1: MD010 Hard tabs found"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md011.rs
+++ b/src/lint/rules/md011.rs
@@ -88,6 +88,7 @@ impl Rule for MD011 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -107,8 +108,12 @@ mod tests {
         let rule = MD011;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 1);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:9: MD011 Reversed link syntax (found '(text)[url]', should be '[text](url)')"
+            ]
+        );
     }
 
     #[test]
@@ -118,7 +123,13 @@ mod tests {
         let rule = MD011;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:7: MD011 Reversed link syntax (found '(text)[url]', should be '[text](url)')",
+                "test.md:1:31: MD011 Reversed link syntax (found '(text)[url]', should be '[text](url)')",
+            ]
+        );
     }
 
     #[test]
@@ -128,8 +139,12 @@ mod tests {
         let rule = MD011;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 1);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:25: MD011 Reversed link syntax (found '(text)[url]', should be '[text](url)')"
+            ]
+        );
     }
 
     #[test]
@@ -174,7 +189,11 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // Should only flag the actual reversed link, not code
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 8);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:8:6: MD011 Reversed link syntax (found '(text)[url]', should be '[text](url)')"
+            ]
+        );
     }
 }

--- a/src/lint/rules/md012.rs
+++ b/src/lint/rules/md012.rs
@@ -99,6 +99,7 @@ impl Rule for MD012 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -134,8 +135,10 @@ mod tests {
         let rule = MD012;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 3); // Third line is the excess blank
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:3:1: MD012 Multiple consecutive blank lines [Expected: 1; Actual: 2]"]
+        );
     }
 
     #[test]
@@ -164,7 +167,10 @@ mod tests {
         let rule = MD012;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:3:1: MD012 Expected: 1; Actual: 2"]
+        );
     }
 
     #[test]
@@ -178,7 +184,10 @@ mod tests {
         let parser = MarkdownParser::new(content);
         let rule = MD012;
         let violations = rule.check(&parser, None);
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:3:1: MD012 Multiple consecutive blank lines [Expected: 1; Actual: 2]"]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(
             fixed,

--- a/src/lint/rules/md013.rs
+++ b/src/lint/rules/md013.rs
@@ -158,6 +158,7 @@ impl Rule for MD013 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -181,8 +182,10 @@ mod tests {
         let config = serde_json::json!({ "line_length": 80 });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:81: MD013 Line exceeds maximum length (105 > 80)"]
+        );
     }
 
     #[test]
@@ -193,7 +196,10 @@ mod tests {
         let config = serde_json::json!({ "line_length": 30 });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:31: MD013 Line exceeds maximum length (38 > 30)"]
+        );
     }
 
     #[test]
@@ -219,7 +225,10 @@ mod tests {
         let config = serde_json::json!({ "line_length": 80, "code_blocks": true });
         let violations = rule.check(&parser, Some(&config));
 
-        assert!(!violations.is_empty());
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:81: MD013 Line exceeds maximum length (89 > 80)"]
+        );
     }
 
     #[test]
@@ -290,8 +299,8 @@ mod tests {
         let violations = rule.check(&parser, Some(&config));
 
         assert_eq!(
-            violations.len(),
-            1,
+            rendered(&violations),
+            ["test.md:1:81: MD013 Line exceeds maximum length (132 > 80)"],
             "Lines with text and links should still be checked"
         );
     }
@@ -308,12 +317,14 @@ mod tests {
         let config = serde_json::json!({ "line_length": 10, "tables": true });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 4);
-        assert!(
-            violations
-                .iter()
-                .enumerate()
-                .all(|(i, v)| v.line == (i + 1))
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:11: MD013 Line exceeds maximum length (15 > 10)",
+                "test.md:2:11: MD013 Line exceeds maximum length (15 > 10)",
+                "test.md:3:11: MD013 Line exceeds maximum length (15 > 10)",
+                "test.md:4:11: MD013 Line exceeds maximum length (15 > 10)",
+            ]
         );
     }
 

--- a/src/lint/rules/md014.rs
+++ b/src/lint/rules/md014.rs
@@ -115,6 +115,7 @@ impl Rule for MD014 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -149,9 +150,13 @@ mod tests {
         let rule = MD014;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2); // One for each line with $
-        assert_eq!(violations[0].line, 2); // First line of code content
-        assert_eq!(violations[1].line, 3); // Second line of code content
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:2:1: MD014 Dollar signs should not be used before commands without showing output",
+                "test.md:3:1: MD014 Dollar signs should not be used before commands without showing output",
+            ]
+        );
     }
 
     #[test]
@@ -194,7 +199,13 @@ mod tests {
         let parser = MarkdownParser::new(content);
         let rule = MD014;
         let violations = rule.check(&parser, None);
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:2:1: MD014 Dollar signs should not be used before commands without showing output",
+                "test.md:3:1: MD014 Dollar signs should not be used before commands without showing output",
+            ]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(
             fixed,

--- a/src/lint/rules/md018.rs
+++ b/src/lint/rules/md018.rs
@@ -77,6 +77,7 @@ impl Rule for MD018 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -106,8 +107,10 @@ mod tests {
         let rule = MD018;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:2: MD018 No space after hash on atx style heading"]
+        );
     }
 
     #[test]
@@ -120,7 +123,13 @@ mod tests {
         let rule = MD018;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:2: MD018 No space after hash on atx style heading",
+                "test.md:2:3: MD018 No space after hash on atx style heading",
+            ]
+        );
     }
 
     #[test]
@@ -159,7 +168,13 @@ mod tests {
         let parser = MarkdownParser::new(content);
         let rule = MD018;
         let violations = rule.check(&parser, None);
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:2: MD018 No space after hash on atx style heading",
+                "test.md:3:3: MD018 No space after hash on atx style heading",
+            ]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(
             fixed,

--- a/src/lint/rules/md019.rs
+++ b/src/lint/rules/md019.rs
@@ -80,6 +80,7 @@ impl Rule for MD019 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -109,8 +110,10 @@ mod tests {
         let rule = MD019;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:3: MD019 Multiple spaces after hash on atx style heading (2 spaces)"]
+        );
     }
 
     #[test]
@@ -120,8 +123,10 @@ mod tests {
         let rule = MD019;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("5 spaces"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:5: MD019 Multiple spaces after hash on atx style heading (5 spaces)"]
+        );
     }
 
     #[test]
@@ -150,7 +155,13 @@ mod tests {
         let parser = MarkdownParser::new(content);
         let rule = MD019;
         let violations = rule.check(&parser, None);
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:3: MD019 Multiple spaces after hash on atx style heading (2 spaces)",
+                "test.md:3:5: MD019 Multiple spaces after hash on atx style heading (3 spaces)",
+            ]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(
             fixed,

--- a/src/lint/rules/md020.rs
+++ b/src/lint/rules/md020.rs
@@ -90,6 +90,7 @@ impl Rule for MD020 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -115,7 +116,10 @@ mod tests {
         let rule = MD020;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1); // No space, violation
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD020 No space inside hashes on closed atx style heading"]
+        );
     }
 
     #[test]
@@ -135,7 +139,13 @@ mod tests {
         let rule = MD020;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2); // Both missing spaces
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:1: MD020 No space inside hashes on closed atx style heading",
+                "test.md:2:1: MD020 No space inside hashes on closed atx style heading",
+            ]
+        );
     }
 
     #[test]
@@ -144,7 +154,10 @@ mod tests {
         let parser = MarkdownParser::new(content);
         let rule = MD020;
         let violations = rule.check(&parser, None);
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD020 No space inside hashes on closed atx style heading"]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(fixed, "# Heading #\n");
     }

--- a/src/lint/rules/md021.rs
+++ b/src/lint/rules/md021.rs
@@ -86,6 +86,7 @@ impl Rule for MD021 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();
@@ -111,7 +112,10 @@ mod tests {
         let rule = MD021;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD021 Multiple spaces inside hashes on closed atx style heading"]
+        );
     }
 
     #[test]
@@ -140,7 +144,10 @@ mod tests {
         let parser = MarkdownParser::new(content);
         let rule = MD021;
         let violations = rule.check(&parser, None);
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD021 Multiple spaces inside hashes on closed atx style heading"]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(fixed, "# Heading ##\n");
     }

--- a/src/lint/rules/md022.rs
+++ b/src/lint/rules/md022.rs
@@ -111,6 +111,7 @@ impl Rule for MD022 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -146,8 +147,10 @@ mod tests {
         let rule = MD022;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("before"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD022 Heading should be surrounded by blank lines (missing before)"]
+        );
     }
 
     #[test]
@@ -160,8 +163,10 @@ mod tests {
         let rule = MD022;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("after"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD022 Heading should be surrounded by blank lines (missing after)"]
+        );
     }
 
     #[test]
@@ -188,8 +193,10 @@ mod tests {
         let parser = MarkdownParser::new(content);
         let rule = MD022;
         let violations = rule.check(&parser, None);
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("before"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD022 Heading should be surrounded by blank lines (missing before)"]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(
             fixed,
@@ -212,8 +219,10 @@ mod tests {
         let parser = MarkdownParser::new(content);
         let rule = MD022;
         let violations = rule.check(&parser, None);
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("after"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD022 Heading should be surrounded by blank lines (missing after)"]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(
             fixed,

--- a/src/lint/rules/md023.rs
+++ b/src/lint/rules/md023.rs
@@ -72,6 +72,7 @@ impl Rule for MD023 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -101,8 +102,12 @@ mod tests {
         let rule = MD023;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 1);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:1: MD023 Heading must start at the beginning of the line (1 space(s) before)"
+            ]
+        );
     }
 
     #[test]
@@ -136,8 +141,12 @@ mod tests {
         let rule = MD023;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("2 space"));
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:1: MD023 Heading must start at the beginning of the line (2 space(s) before)"
+            ]
+        );
     }
 
     #[test]
@@ -150,7 +159,12 @@ mod tests {
         let parser = MarkdownParser::new(content);
         let rule = MD023;
         let violations = rule.check(&parser, None);
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:1: MD023 Heading must start at the beginning of the line (1 space(s) before)"
+            ]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(
             fixed,

--- a/src/lint/rules/md024.rs
+++ b/src/lint/rules/md024.rs
@@ -118,6 +118,7 @@ impl Rule for MD024 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -143,8 +144,12 @@ mod tests {
         let rule = MD024;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("Heading"));
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:3:1: MD024 Multiple headings with the same content: \"Heading\" (first at line 1)",
+            ]
+        );
     }
 
     #[test]
@@ -172,7 +177,12 @@ mod tests {
         let config = serde_json::json!({ "siblings_only": true });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:3:1: MD024 Multiple sibling headings with the same content: \"Heading\" (first at line 1)",
+            ]
+        );
     }
 
     #[test]
@@ -209,10 +219,11 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         assert_eq!(
-            violations.len(),
-            1,
+            rendered(&violations),
+            [
+                "test.md:5:1: MD024 Multiple headings with the same content: \"`mdlint check`\" (first at line 1)"
+            ],
             "Same code headings should be duplicates"
         );
-        assert!(violations[0].message.contains("`mdlint check`"));
     }
 }

--- a/src/lint/rules/md025.rs
+++ b/src/lint/rules/md025.rs
@@ -58,6 +58,7 @@ impl Rule for MD025 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -83,8 +84,10 @@ mod tests {
         let rule = MD025;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 3);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:3:1: MD025 Multiple top-level headings (first h1 at line 1)"]
+        );
     }
 
     #[test]
@@ -97,7 +100,13 @@ mod tests {
         let rule = MD025;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2); // Second and third are violations
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:2:1: MD025 Multiple top-level headings (first h1 at line 1)",
+                "test.md:3:1: MD025 Multiple top-level headings (first h1 at line 1)",
+            ]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md026.rs
+++ b/src/lint/rules/md026.rs
@@ -73,6 +73,7 @@ impl Rule for MD026 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
 
     #[test]
     fn test_no_trailing_punctuation() {
@@ -91,8 +92,10 @@ mod tests {
         let rule = MD026;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("'.'"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD026 Trailing punctuation in heading: '.'"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md027.rs
+++ b/src/lint/rules/md027.rs
@@ -72,6 +72,7 @@ impl Rule for MD027 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -98,8 +99,10 @@ mod tests {
         let rule = MD027;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:2: MD027 Multiple spaces after blockquote symbol (2 spaces)"]
+        );
     }
 
     #[test]
@@ -109,8 +112,10 @@ mod tests {
         let rule = MD027;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("5 spaces"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:2: MD027 Multiple spaces after blockquote symbol (5 spaces)"]
+        );
     }
 
     #[test]
@@ -132,7 +137,10 @@ mod tests {
         let parser = MarkdownParser::new(content);
         let rule = MD027;
         let violations = rule.check(&parser, None);
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:2: MD027 Multiple spaces after blockquote symbol (2 spaces)"]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(
             fixed,

--- a/src/lint/rules/md028.rs
+++ b/src/lint/rules/md028.rs
@@ -76,6 +76,7 @@ impl Rule for MD028 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -101,8 +102,10 @@ mod tests {
         let rule = MD028;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 2);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD028 Blank line inside blockquote"]
+        );
     }
 
     #[test]
@@ -129,6 +132,9 @@ mod tests {
         let rule = MD028;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1); // First blank line is the violation
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD028 Blank line inside blockquote"]
+        );
     }
 }

--- a/src/lint/rules/md029.rs
+++ b/src/lint/rules/md029.rs
@@ -132,6 +132,7 @@ fn parse_item_number(trimmed: &str) -> Option<usize> {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -166,9 +167,13 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // Default "ordered": items 2 and 3 should be 2 and 3, not 1
-        assert_eq!(violations.len(), 2);
-        assert_eq!(violations[0].line, 2);
-        assert_eq!(violations[1].line, 3);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:2:1: MD029 Ordered list item prefix: expected 2, found 1",
+                "test.md:3:1: MD029 Ordered list item prefix: expected 3, found 1",
+            ]
+        );
     }
 
     #[test]
@@ -181,9 +186,13 @@ mod tests {
         let rule = MD029;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2); // Lines 2 and 3 are wrong
-        assert_eq!(violations[0].line, 2);
-        assert_eq!(violations[1].line, 3);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:2:1: MD029 Ordered list item prefix: expected 2, found 3",
+                "test.md:3:1: MD029 Ordered list item prefix: expected 3, found 4",
+            ]
+        );
     }
 
     #[test]
@@ -194,8 +203,10 @@ mod tests {
         let config = serde_json::json!({ "style": "ordered" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 2);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD029 Ordered list item prefix: expected 2, found 1"]
+        );
     }
 
     #[test]
@@ -206,8 +217,10 @@ mod tests {
         let config = serde_json::json!({ "style": "one" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 2);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD029 Ordered list item prefix: expected 1, found 2"]
+        );
     }
 
     #[test]
@@ -236,7 +249,13 @@ mod tests {
         let rule = MD029;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:2:1: MD029 Ordered list item prefix: expected 2, found 1",
+                "test.md:3:1: MD029 Ordered list item prefix: expected 3, found 1",
+            ]
+        );
         let fix0 = violations[0].fix.as_ref().expect("fix should be Some");
         assert_eq!(fix0.line_start, 2);
         assert_eq!(fix0.replacement, "2");
@@ -257,7 +276,10 @@ mod tests {
         let rule = MD029;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:5:1: MD029 Ordered list item prefix: expected 2, found 1"]
+        );
         let fix = violations[0].fix.as_ref().expect("fix should be Some");
         assert_eq!(fix.replacement, "2");
         assert_eq!(fix.column_start, Some(1));

--- a/src/lint/rules/md030.rs
+++ b/src/lint/rules/md030.rs
@@ -235,6 +235,7 @@ fn is_table_separator(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -258,8 +259,10 @@ mod tests {
         let rule = MD030;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("found 0"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:2: MD030 Expected 1 space(s) after list marker, found 0"]
+        );
     }
 
     #[test]
@@ -269,8 +272,10 @@ mod tests {
         let rule = MD030;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("found 2"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:2: MD030 Expected 1 space(s) after list marker, found 2"]
+        );
     }
 
     #[test]
@@ -383,11 +388,10 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         assert_eq!(
-            violations.len(),
-            1,
+            rendered(&violations),
+            ["test.md:5:2: MD030 Expected 1 space(s) after list marker, found 0"],
             "Real list markers outside code blocks should be checked"
         );
-        assert_eq!(violations[0].line, 5);
     }
 
     #[test]

--- a/src/lint/rules/md031.rs
+++ b/src/lint/rules/md031.rs
@@ -121,6 +121,7 @@ impl Rule for MD031 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -153,8 +154,12 @@ mod tests {
         let rule = MD031;
         let violations = rule.check(&parser, None);
 
-        assert!(!violations.is_empty());
-        assert!(violations.iter().any(|v| v.message.contains("before")));
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:2:1: MD031 Fenced code blocks should be surrounded by blank lines (missing before)"
+            ]
+        );
     }
 
     #[test]
@@ -170,8 +175,12 @@ mod tests {
         let rule = MD031;
         let violations = rule.check(&parser, None);
 
-        assert!(!violations.is_empty());
-        assert!(violations.iter().any(|v| v.message.contains("after")));
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:5:1: MD031 Fenced code blocks should be surrounded by blank lines (missing after)"
+            ]
+        );
     }
 
     #[test]
@@ -205,8 +214,12 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // Should detect missing blank line before code block
-        assert!(!violations.is_empty());
-        assert!(violations.iter().any(|v| v.message.contains("before")));
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:2:1: MD031 Fenced code blocks should be surrounded by blank lines (missing before)"
+            ]
+        );
 
         // Check that fix has correct line numbers
         if let Some(fix) = &violations[0].fix {
@@ -232,7 +245,13 @@ mod tests {
         let rule = MD031;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2); // Missing before and after
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:2:1: MD031 Fenced code blocks should be surrounded by blank lines (missing before)",
+                "test.md:4:1: MD031 Fenced code blocks should be surrounded by blank lines (missing after)",
+            ]
+        );
 
         // Apply fixes
         let fixes: Vec<_> = violations.iter().filter_map(|v| v.fix.clone()).collect();

--- a/src/lint/rules/md032.rs
+++ b/src/lint/rules/md032.rs
@@ -199,6 +199,7 @@ fn get_list_marker(trimmed: &str) -> Option<ListMarker> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -229,8 +230,10 @@ mod tests {
         let rule = MD032;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 2); // List starts on line 2
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD032 List should be surrounded by blank lines"]
+        );
     }
 
     #[test]
@@ -245,8 +248,10 @@ mod tests {
         let rule = MD032;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert_eq!(violations[0].line, 5); // Text after list
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:5:1: MD032 List should be surrounded by blank lines"]
+        );
     }
 
     #[test]
@@ -356,10 +361,21 @@ mod tests {
         let rule = MD032;
         let violations = rule.check(&parser, None);
 
-        // Each marker change is a new list needing blank lines
-        // + needs blank before/after (2 violations)
-        // - needs blank before/after (2 violations)
-        assert_eq!(violations.len(), 4);
+        // Each marker change starts a new list, so every boundary reports both
+        // "previous list needs a blank after" and "new list needs a blank
+        // before".
+        // AIDEV: at line 4 those two land on the same line with the same
+        // message, so they read as one duplicated diagnostic; MD031 avoids this
+        // by tagging its equivalents "(missing before)" / "(missing after)".
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:3:1: MD032 List should be surrounded by blank lines",
+                "test.md:4:1: MD032 List should be surrounded by blank lines",
+                "test.md:4:1: MD032 List should be surrounded by blank lines",
+                "test.md:5:1: MD032 List should be surrounded by blank lines",
+            ]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md033.rs
+++ b/src/lint/rules/md033.rs
@@ -91,6 +91,7 @@ fn extract_tag_name(html: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -113,8 +114,10 @@ mod tests {
         let rule = MD033;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("<br>"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD033 Inline HTML element: <br>"]
+        );
     }
 
     #[test]
@@ -126,8 +129,10 @@ mod tests {
         let violations = rule.check(&parser, Some(&config));
 
         // Only <div> should be flagged, <br> is allowed
-        assert!(!violations.is_empty());
-        assert!(violations.iter().any(|v| v.message.contains("<div>")));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD033 Inline HTML element: <div>"]
+        );
     }
 
     #[test]
@@ -140,6 +145,9 @@ mod tests {
         let rule = MD033;
         let violations = rule.check(&parser, None);
 
-        assert!(!violations.is_empty());
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD033 Inline HTML element: <div>"]
+        );
     }
 }

--- a/src/lint/rules/md034.rs
+++ b/src/lint/rules/md034.rs
@@ -71,6 +71,7 @@ impl Rule for MD034 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -90,8 +91,10 @@ mod tests {
         let rule = MD034;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("https://example.com"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:11: MD034 Bare URL used: https://example.com"]
+        );
     }
 
     #[test]
@@ -111,7 +114,13 @@ mod tests {
         let rule = MD034;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:7: MD034 Bare URL used: https://example.com",
+                "test.md:1:31: MD034 Bare URL used: https://test.com",
+            ]
+        );
     }
 
     #[test]
@@ -188,8 +197,10 @@ mod tests {
         let rule = MD034;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("https://paren.example.com"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:12: MD034 Bare URL used: https://paren.example.com"]
+        );
     }
 
     #[test]
@@ -199,9 +210,11 @@ mod tests {
         let rule = MD034;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:7: MD034 Bare URL used: https://example.com"]
+        );
         // "Visit " is 6 chars, URL starts at column 7 (1-indexed).
-        assert_eq!(violations[0].column, Some(7));
     }
 
     #[test]

--- a/src/lint/rules/md035.rs
+++ b/src/lint/rules/md035.rs
@@ -120,6 +120,7 @@ fn get_hr_style(line: &str) -> String {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -156,7 +157,10 @@ mod tests {
         let rule = MD035;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:5:1: MD035 Horizontal rule style should be '---', found '***'"]
+        );
     }
 
     #[test]
@@ -170,7 +174,10 @@ mod tests {
         let config = serde_json::json!({ "style": "---" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD035 Horizontal rule style should be '---', found '***'"]
+        );
     }
 
     #[test]
@@ -216,7 +223,10 @@ mod tests {
         let rule = MD035;
         let config = serde_json::json!({ "style": "---" });
         let violations = rule.check(&parser, Some(&config));
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD035 Horizontal rule style should be '---', found '***'"]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(
             fixed,

--- a/src/lint/rules/md036.rs
+++ b/src/lint/rules/md036.rs
@@ -107,6 +107,7 @@ fn is_emphasis_only_line(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -129,7 +130,10 @@ mod tests {
         let rule = MD036;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD036 Emphasis used instead of a heading"]
+        );
     }
 
     #[test]
@@ -162,7 +166,10 @@ mod tests {
         let rule = MD036;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD036 Emphasis used instead of a heading"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md037.rs
+++ b/src/lint/rules/md037.rs
@@ -202,6 +202,7 @@ impl Rule for MD037 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -221,7 +222,14 @@ mod tests {
         let rule = MD037;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2); // One for opening, one for closing
+        // One violation for the opening marker, one for the closing.
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:9: MD037 Spaces inside emphasis markers",
+                "test.md:1:16: MD037 Spaces inside emphasis markers",
+            ]
+        );
     }
 
     #[test]
@@ -231,7 +239,14 @@ mod tests {
         let rule = MD037;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2); // One for opening, one for closing
+        // One violation for the opening marker, one for the closing.
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:9: MD037 Spaces inside emphasis markers",
+                "test.md:1:17: MD037 Spaces inside emphasis markers",
+            ]
+        );
     }
 
     #[test]
@@ -241,7 +256,14 @@ mod tests {
         let rule = MD037;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2); // One for opening, one for closing
+        // One violation for the opening marker, one for the closing.
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:9: MD037 Spaces inside emphasis markers",
+                "test.md:1:16: MD037 Spaces inside emphasis markers",
+            ]
+        );
     }
 
     #[test]
@@ -279,7 +301,15 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // The * 2 * 3 part should be flagged (not in code), but user_id should not
-        assert_eq!(violations.len(), 2); // Only the * 2 * emphasis
+        // Only the `* 2 *` emphasis is flagged; the underscores inside the
+        // `user_id` code span are not emphasis markers.
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:32: MD037 Spaces inside emphasis markers",
+                "test.md:1:35: MD037 Spaces inside emphasis markers",
+            ]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md038.rs
+++ b/src/lint/rules/md038.rs
@@ -85,6 +85,7 @@ impl Rule for MD038 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
 
     #[test]
     fn test_correct_code_span() {
@@ -103,7 +104,10 @@ mod tests {
         let rule = MD038;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:10: MD038 Spaces inside code span elements"]
+        );
     }
 
     #[test]
@@ -113,7 +117,10 @@ mod tests {
         let rule = MD038;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:20: MD038 Spaces inside code span elements"]
+        );
     }
 
     #[test]
@@ -156,7 +163,10 @@ mod tests {
         let rule = MD038;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:6: MD038 Spaces inside code span elements"]
+        );
     }
 
     #[test]
@@ -166,7 +176,10 @@ mod tests {
         let rule = MD038;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:10: MD038 Spaces inside code span elements"]
+        );
     }
 
     #[test]
@@ -192,6 +205,9 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // The parser sees ` code` (leading space without trailing), which is flagged
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:6: MD038 Spaces inside code span elements"]
+        );
     }
 }

--- a/src/lint/rules/md039.rs
+++ b/src/lint/rules/md039.rs
@@ -69,6 +69,7 @@ impl Rule for MD039 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
 
     #[test]
     fn test_correct_link() {
@@ -87,7 +88,10 @@ mod tests {
         let rule = MD039;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD039 Spaces inside link text"]
+        );
     }
 
     #[test]
@@ -97,7 +101,10 @@ mod tests {
         let rule = MD039;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD039 Spaces inside link text"]
+        );
     }
 
     #[test]
@@ -107,8 +114,16 @@ mod tests {
         let rule = MD039;
         let violations = rule.check(&parser, None);
 
-        // Should report 2 violations: one for leading space, one for trailing
-        assert_eq!(violations.len(), 2);
+        // AIDEV: the leading- and trailing-space violations are reported at the
+        // match start with the same message, so the two are indistinguishable.
+        // Pointing the trailing one at the trailing space would separate them.
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:1: MD039 Spaces inside link text",
+                "test.md:1:1: MD039 Spaces inside link text",
+            ]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md040.rs
+++ b/src/lint/rules/md040.rs
@@ -71,6 +71,7 @@ impl Rule for MD040 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -97,8 +98,10 @@ mod tests {
         let config = serde_json::json!({ "allowed_languages": ["rust", "python"] });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("should have a language"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD040 Fenced code block should have a language specified"]
+        );
     }
 
     #[test]
@@ -112,8 +115,10 @@ mod tests {
         let config = serde_json::json!({ "allowed_languages": ["rust", "python"] });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("not in the allowed list"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD040 Language 'javascript' is not in the allowed list"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md041.rs
+++ b/src/lint/rules/md041.rs
@@ -94,6 +94,7 @@ impl Rule for MD041 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -119,7 +120,10 @@ mod tests {
         let rule = MD041;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD041 First line in file should be a top-level heading"]
+        );
     }
 
     #[test]
@@ -132,7 +136,10 @@ mod tests {
         let rule = MD041;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1); // Should be H1
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD041 First line in file should be a level 1 heading"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md042.rs
+++ b/src/lint/rules/md042.rs
@@ -50,6 +50,7 @@ impl Rule for MD042 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
 
     #[test]
     fn test_link_with_text() {
@@ -68,7 +69,9 @@ mod tests {
         let rule = MD042;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        // AIDEV: the empty link starts at column 18, but MD042 reports every
+        // violation at column 1, so the column cannot locate it on the line.
+        assert_eq!(rendered(&violations), ["test.md:1:1: MD042 No empty links"]);
     }
 
     #[test]
@@ -90,7 +93,7 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // Empty fragment should trigger MD042
-        assert_eq!(violations.len(), 1);
+        assert_eq!(rendered(&violations), ["test.md:1:1: MD042 No empty links"]);
     }
 
     #[test]
@@ -100,6 +103,6 @@ mod tests {
         let rule = MD042;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1); // Only second link has empty destination
+        assert_eq!(rendered(&violations), ["test.md:1:1: MD042 No empty links"]);
     }
 }

--- a/src/lint/rules/md043.rs
+++ b/src/lint/rules/md043.rs
@@ -112,6 +112,7 @@ impl Rule for MD043 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -150,8 +151,10 @@ mod tests {
         });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("Wrong Heading"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD043 Expected heading 'Background', found 'Wrong Heading'"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md044.rs
+++ b/src/lint/rules/md044.rs
@@ -87,6 +87,7 @@ impl Rule for MD044 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
 
     #[test]
     fn test_no_config() {
@@ -121,7 +122,13 @@ mod tests {
         });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:8: MD044 Proper name 'javascript' should be capitalized as 'JavaScript'",
+                "test.md:1:23: MD044 Proper name 'typescript' should be capitalized as 'TypeScript'",
+            ]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md045.rs
+++ b/src/lint/rules/md045.rs
@@ -63,6 +63,7 @@ impl Rule for MD045 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
 
     #[test]
     fn test_image_with_alt() {
@@ -81,7 +82,12 @@ mod tests {
         let rule = MD045;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        // AIDEV: the alt-less image starts at column 23, but MD045 reports every
+        // violation at column 1, so the column cannot locate it on the line.
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD045 Images should have alternate text (alt text)"]
+        );
     }
 
     #[test]
@@ -101,6 +107,9 @@ mod tests {
         let rule = MD045;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1); // Only second image lacks alt
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD045 Images should have alternate text (alt text)"]
+        );
     }
 }

--- a/src/lint/rules/md046.rs
+++ b/src/lint/rules/md046.rs
@@ -107,6 +107,7 @@ impl Rule for MD046 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -149,7 +150,10 @@ mod tests {
         let rule = MD046;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:5:1: MD046 Code block style should be 'fenced', found 'indented'"]
+        );
     }
 
     #[test]
@@ -160,6 +164,9 @@ mod tests {
         let config = serde_json::json!({ "style": "fenced" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD046 Code block style should be 'fenced', found 'indented'"]
+        );
     }
 }

--- a/src/lint/rules/md047.rs
+++ b/src/lint/rules/md047.rs
@@ -93,6 +93,7 @@ impl Rule for MD047 {
 mod tests {
     use super::*;
     use crate::fix::Fixer;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     fn apply_fixes(content: &str, violations: &[Violation]) -> String {
@@ -126,7 +127,10 @@ mod tests {
         let rule = MD047;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:3:1: MD047 Files should end with a single newline character"]
+        );
     }
 
     #[test]
@@ -141,7 +145,10 @@ mod tests {
         let rule = MD047;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:4:1: MD047 Files should end with a single newline character"]
+        );
     }
 
     #[test]
@@ -163,7 +170,10 @@ mod tests {
         let parser = MarkdownParser::new(content);
         let rule = MD047;
         let violations = rule.check(&parser, None);
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:3:1: MD047 Files should end with a single newline character"]
+        );
         let fixed = apply_fixes(content, &violations);
         assert_eq!(
             fixed,

--- a/src/lint/rules/md048.rs
+++ b/src/lint/rules/md048.rs
@@ -111,6 +111,7 @@ impl Rule for MD048 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -162,7 +163,11 @@ mod tests {
         let rule = MD048;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1); // Only opening of second block
+        // Only the opening fence of the offending block is reported.
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:5:1: MD048 Code fence style should be 'backtick' (`), found tilde (~)"]
+        );
     }
 
     #[test]
@@ -176,6 +181,10 @@ mod tests {
         let config = serde_json::json!({ "style": "backtick" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1); // Only opening
+        // Only the opening fence is reported, not the closing one.
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD048 Code fence style should be 'backtick' (`), found tilde (~)"]
+        );
     }
 }

--- a/src/lint/rules/md049.rs
+++ b/src/lint/rules/md049.rs
@@ -166,6 +166,7 @@ impl Rule for MD049 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -197,7 +198,13 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // Reports violation for both opening and closing markers of the second emphasis
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:22: MD049 Emphasis style should be '*', found '_'",
+                "test.md:1:34: MD049 Emphasis style should be '*', found '_'",
+            ]
+        );
     }
 
     #[test]
@@ -209,7 +216,13 @@ mod tests {
         let violations = rule.check(&parser, Some(&config));
 
         // Reports violation for both opening and closing markers
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:9: MD049 Emphasis style should be '*', found '_'",
+                "test.md:1:16: MD049 Emphasis style should be '*', found '_'",
+            ]
+        );
     }
 
     #[test]
@@ -272,7 +285,13 @@ mod tests {
         let config = serde_json::json!({ "style": "asterisk" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:6: MD049 Emphasis style should be '*', found '_'",
+                "test.md:1:13: MD049 Emphasis style should be '*', found '_'",
+            ]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md050.rs
+++ b/src/lint/rules/md050.rs
@@ -172,6 +172,7 @@ impl Rule for MD050 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -203,7 +204,13 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // Reports violation for both opening and closing markers of the second strong emphasis
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:22: MD050 Strong style should be '**', found '__'",
+                "test.md:1:33: MD050 Strong style should be '**', found '__'",
+            ]
+        );
     }
 
     #[test]
@@ -215,7 +222,13 @@ mod tests {
         let violations = rule.check(&parser, Some(&config));
 
         // Reports violation for both opening and closing markers
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:9: MD050 Strong style should be '**', found '__'",
+                "test.md:1:15: MD050 Strong style should be '**', found '__'",
+            ]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md051.rs
+++ b/src/lint/rules/md051.rs
@@ -134,6 +134,7 @@ fn heading_to_id(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -159,8 +160,10 @@ mod tests {
         let rule = MD051;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("nonexistent"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:3:1: MD051 Link fragment 'nonexistent' does not match any heading"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md052.rs
+++ b/src/lint/rules/md052.rs
@@ -60,6 +60,7 @@ impl Rule for MD052 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -82,8 +83,10 @@ mod tests {
         let rule = MD052;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("undefined"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD052 Reference link label 'undefined' is not defined"]
+        );
     }
 
     #[test]
@@ -132,8 +135,10 @@ mod tests {
         let rule = MD052;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("reference"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD052 Reference link label 'reference' is not defined"]
+        );
     }
 
     #[test]
@@ -156,6 +161,9 @@ mod tests {
         let rule = MD052;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD052 Reference link label 'Link' is not defined"]
+        );
     }
 }

--- a/src/lint/rules/md053.rs
+++ b/src/lint/rules/md053.rs
@@ -73,6 +73,7 @@ impl Rule for MD053 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -98,8 +99,10 @@ mod tests {
         let rule = MD053;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("unused"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD053 Link reference definition 'unused' is defined but not used"]
+        );
     }
 
     #[test]
@@ -113,8 +116,10 @@ mod tests {
         let rule = MD053;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("unused"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD053 Link reference definition 'unused' is defined but not used"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md054.rs
+++ b/src/lint/rules/md054.rs
@@ -89,6 +89,7 @@ impl Rule for MD054 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -126,7 +127,12 @@ mod tests {
         let config = serde_json::json!({ "style": "consistent" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:3:1: MD054 Link/image style should be consistent: expected 'inline', found 'reference'",
+            ]
+        );
     }
 
     #[test]
@@ -140,7 +146,10 @@ mod tests {
         let config = serde_json::json!({ "style": "inline" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:3:1: MD054 Link/image style should be 'inline', found 'reference'"]
+        );
     }
 
     #[test]
@@ -151,6 +160,9 @@ mod tests {
         let config = serde_json::json!({ "style": "reference" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD054 Link/image style should be 'reference', found 'inline'"]
+        );
     }
 }

--- a/src/lint/rules/md055.rs
+++ b/src/lint/rules/md055.rs
@@ -175,6 +175,7 @@ impl Rule for MD055 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -215,7 +216,13 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // Last row is inconsistent: reports 2 violations (missing leading and trailing)
-        assert_eq!(violations.len(), 2);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:3:1: MD055 Table should have leading pipe",
+                "test.md:3:1: MD055 Table should have trailing pipe",
+            ]
+        );
     }
 
     #[test]
@@ -230,7 +237,17 @@ mod tests {
         let violations = rule.check(&parser, Some(&config));
 
         // 3 rows (header, separator, data) × 2 violations each (missing leading and trailing)
-        assert_eq!(violations.len(), 6);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:1: MD055 Table should have leading pipe",
+                "test.md:1:1: MD055 Table should have trailing pipe",
+                "test.md:2:1: MD055 Table should have leading pipe",
+                "test.md:2:1: MD055 Table should have trailing pipe",
+                "test.md:3:1: MD055 Table should have leading pipe",
+                "test.md:3:1: MD055 Table should have trailing pipe",
+            ]
+        );
     }
 
     #[test]
@@ -274,6 +291,16 @@ mod tests {
         let violations = rule.check(&parser, Some(&config));
 
         // 3 rows x 2 violations each (missing leading and trailing pipe)
-        assert_eq!(violations.len(), 6);
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:1: MD055 Table should have leading pipe",
+                "test.md:1:1: MD055 Table should have trailing pipe",
+                "test.md:2:1: MD055 Table should have leading pipe",
+                "test.md:2:1: MD055 Table should have trailing pipe",
+                "test.md:3:1: MD055 Table should have leading pipe",
+                "test.md:3:1: MD055 Table should have trailing pipe",
+            ]
+        );
     }
 }

--- a/src/lint/rules/md056.rs
+++ b/src/lint/rules/md056.rs
@@ -136,6 +136,7 @@ fn is_separator_line(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -162,7 +163,10 @@ mod tests {
         let rule = MD056;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:3:1: MD056 Table row has 3 columns, expected 2"]
+        );
     }
 
     #[test]
@@ -175,7 +179,10 @@ mod tests {
         let rule = MD056;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1); // Separator has wrong column count
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD056 Table separator has 2 columns, expected 3"]
+        );
     }
 
     #[test]
@@ -190,7 +197,10 @@ mod tests {
         let rule = MD056;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1); // Only middle row is wrong
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:4:1: MD056 Table row has 3 columns, expected 2"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md058.rs
+++ b/src/lint/rules/md058.rs
@@ -79,6 +79,7 @@ fn is_separator_line(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -111,7 +112,10 @@ mod tests {
         let rule = MD058;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD058 Table should be surrounded by blank lines"]
+        );
     }
 
     #[test]
@@ -144,7 +148,10 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // Only violation is missing blank line before table
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD058 Table should be surrounded by blank lines"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/md059.rs
+++ b/src/lint/rules/md059.rs
@@ -82,6 +82,7 @@ impl Rule for MD059 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
 
     #[test]
     fn test_descriptive_link() {
@@ -100,8 +101,10 @@ mod tests {
         let rule = MD059;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].message.contains("Click here"));
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD059 Link text 'Click here' is not descriptive; use meaningful text"]
+        );
     }
 
     #[test]
@@ -111,7 +114,10 @@ mod tests {
         let rule = MD059;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD059 Link text 'here' is not descriptive; use meaningful text"]
+        );
     }
 
     #[test]
@@ -121,7 +127,15 @@ mod tests {
         let rule = MD059;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 2);
+        // AIDEV: both links report column 1 ("read more" actually starts at
+        // column 25); only the quoted text in the message distinguishes them.
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:1: MD059 Link text 'Click here' is not descriptive; use meaningful text",
+                "test.md:1:1: MD059 Link text 'read more' is not descriptive; use meaningful text",
+            ]
+        );
     }
 
     #[test]
@@ -131,6 +145,9 @@ mod tests {
         let rule = MD059;
         let violations = rule.check(&parser, None);
 
-        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:1:1: MD059 Link text 'CLICK HERE' is not descriptive; use meaningful text"]
+        );
     }
 }

--- a/src/lint/rules/md060.rs
+++ b/src/lint/rules/md060.rs
@@ -124,6 +124,7 @@ fn parse_alignments(line: &str) -> Vec<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::rules::rendered;
     use indoc::indoc;
 
     #[test]
@@ -164,7 +165,11 @@ mod tests {
         let config = serde_json::json!({ "style": "left" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1); // Second column is right-aligned
+        // Only the second column deviates; it is right-aligned.
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD060 Table column 2 should use 'left' alignment, found 'right'"]
+        );
     }
 
     #[test]
@@ -178,7 +183,11 @@ mod tests {
         let config = serde_json::json!({ "style": "default" });
         let violations = rule.check(&parser, Some(&config));
 
-        assert_eq!(violations.len(), 1); // Second column is left-aligned
+        // Only the second column deviates; it is left-aligned.
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:1: MD060 Table column 2 should use 'default' alignment, found 'left'"]
+        );
     }
 
     #[test]

--- a/src/lint/rules/mod.rs
+++ b/src/lint/rules/mod.rs
@@ -173,3 +173,24 @@ pub fn create_default_registry() -> RuleRegistry {
 
     registry
 }
+
+/// Renders violations exactly as `mdlint check` prints them, one line per
+/// violation, so tests assert the diagnostic a user actually sees rather than
+/// a test-only shape — a change to the displayed format shows up here too.
+/// The path is a fixed stand-in; context lines and colour are disabled.
+#[cfg(test)]
+pub(crate) fn rendered(violations: &[crate::types::Violation]) -> Vec<String> {
+    use crate::format::{DefaultFormatter, Formatter as _};
+
+    let mut result = crate::lint::LintResult::new();
+    result.add_file_result(
+        std::path::PathBuf::from("test.md"),
+        violations.to_vec(),
+        Vec::new(),
+    );
+    DefaultFormatter::without_context(false)
+        .format(&result)
+        .lines()
+        .filter_map(|line| line.strip_prefix("  ").map(str::to_owned))
+        .collect()
+}


### PR DESCRIPTION
Verifying with a single "did it fail a check" value isn't good enough, we need to know the failure text that would appear to a user, which includes the location of the failure and the failure type.