### PR TITLE
Exclude code from regex-scanning rules; rewrite MD039 on events

### DIFF
--- a/src/lint/rules/md011.rs
+++ b/src/lint/rules/md011.rs
@@ -1,7 +1,6 @@
 use crate::lint::rule::Rule;
 use crate::markdown::MarkdownParser;
 use crate::types::Violation;
-use pulldown_cmark::{Event, Tag, TagEnd};
 use regex::Regex;
 use serde_json::Value;
 
@@ -23,29 +22,11 @@ impl Rule for MD011 {
     fn check(&self, parser: &MarkdownParser, _config: Option<&Value>) -> Vec<Violation> {
         let mut violations = Vec::new();
 
-        // Track code blocks to exclude them from checking
-        let mut code_block_lines = std::collections::HashSet::new();
-        let mut in_code_block = false;
-
-        for (event, range) in parser.parse_with_offsets() {
-            match event {
-                Event::Start(Tag::CodeBlock(_)) => {
-                    in_code_block = true;
-                }
-                Event::End(TagEnd::CodeBlock) => {
-                    in_code_block = false;
-                }
-                Event::Text(_) if in_code_block => {
-                    // Mark all lines that this text event spans
-                    let start_line = parser.offset_to_line(range.start);
-                    let end_line = parser.offset_to_line(range.end.saturating_sub(1));
-                    for line in start_line..=end_line {
-                        code_block_lines.insert(line);
-                    }
-                }
-                _ => {}
-            }
-        }
+        // `(text)[url]` isn't a link, so pulldown-cmark emits it as several
+        // separate Text events — the source lines are the only place the whole
+        // pattern is visible. The parser's precomputed code ranges still do the
+        // exclusion, covering code spans as well as code blocks.
+        let code_ranges = parser.get_code_ranges();
 
         // Pattern for reversed link syntax: (text)[url]
         // Capture the bracket content so we can exclude GFM task list checkboxes ([ ], [x], [X])
@@ -54,11 +35,6 @@ impl Rule for MD011 {
         for (line_num, line) in parser.lines().iter().enumerate() {
             let line_number = line_num + 1;
 
-            // Skip code blocks
-            if code_block_lines.contains(&line_number) {
-                continue;
-            }
-
             for caps in re.captures_iter(line) {
                 // Skip GFM task list checkboxes: [ ] and [x]/[X]
                 let bracket_content = &caps[1];
@@ -66,6 +42,10 @@ impl Rule for MD011 {
                     continue;
                 }
                 let m = caps.get(0).expect("group 0 always present");
+                let absolute = parser.line_offset_to_absolute(line_number, m.start());
+                if code_ranges.iter().any(|range| range.contains(&absolute)) {
+                    continue;
+                }
                 violations.push(Violation {
                     line: line_number,
                     column: Some(m.start() + 1),
@@ -165,6 +145,16 @@ mod tests {
             - [x] Done task
             - (description)[ ] another task
         "};
+        let parser = MarkdownParser::new(content);
+        let rule = MD011;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_code_span_not_flagged() {
+        let content = "Use `array(0)[index]` and `function(param)[key]` in code.";
         let parser = MarkdownParser::new(content);
         let rule = MD011;
         let violations = rule.check(&parser, None);

--- a/src/lint/rules/md039.rs
+++ b/src/lint/rules/md039.rs
@@ -1,10 +1,43 @@
 use crate::lint::rule::Rule;
 use crate::markdown::MarkdownParser;
 use crate::types::Violation;
-use regex::Regex;
+use pulldown_cmark::{Event, Tag, TagEnd};
 use serde_json::Value;
+use std::ops::Range;
 
 pub struct MD039;
+
+impl MD039 {
+    /// Reports the leading and the trailing space of `span` separately, each at
+    /// its own column, so two violations on one line can be told apart.
+    fn spaces_in(
+        &self,
+        content: &str,
+        span: &Range<usize>,
+        parser: &MarkdownParser,
+    ) -> Vec<Violation> {
+        let text = &content[span.clone()];
+        let at = |offset: usize| {
+            let (line, column) = parser.offset_to_position(offset);
+            Violation {
+                line,
+                column: Some(column),
+                rule: self.name().to_owned(),
+                message: "Spaces inside link text".to_owned(),
+                fix: None,
+            }
+        };
+
+        let mut violations = Vec::new();
+        if text.starts_with(' ') {
+            violations.push(at(span.start));
+        }
+        if text.ends_with(' ') {
+            violations.push(at(span.end.saturating_sub(1)));
+        }
+        violations
+    }
+}
 
 impl Rule for MD039 {
     fn name(&self) -> &'static str {
@@ -20,41 +53,36 @@ impl Rule for MD039 {
     }
 
     fn check(&self, parser: &MarkdownParser, _config: Option<&Value>) -> Vec<Violation> {
+        // Only the event stream knows what is really link text: it covers every
+        // link form (inline, reference, collapsed) rather than just `[text](url)`,
+        // and code blocks, code spans and task list checkboxes are structurally
+        // excluded because none of them produce a Link.
         let mut violations = Vec::new();
+        let content = parser.content();
+        let mut in_link = false;
+        let mut text_span: Option<Range<usize>> = None;
 
-        // Regex to detect spaces inside link text: [ text](url) or [text ](url)
-        // Use [^\]]+ to avoid matching across ] boundaries (e.g. task list checkboxes like [ ])
-        let pattern = Regex::new(r"\[( [^\]]+|[^\]]+ )\]\([^\)]+\)").expect("valid regex");
-
-        for (line_num, line) in parser.lines().iter().enumerate() {
-            let line_number = line_num + 1;
-
-            for mat in pattern.find_iter(line) {
-                let matched_text = mat.as_str();
-                // Extract the link text between [ and ]
-                if let Some(bracket_end) = matched_text.find(']') {
-                    let link_text = &matched_text[1..bracket_end];
-
-                    // Report separate violations for leading and trailing spaces
-                    if link_text.starts_with(' ') {
-                        violations.push(Violation {
-                            line: line_number,
-                            column: Some(mat.start() + 2),
-                            rule: self.name().to_owned(),
-                            message: "Spaces inside link text".to_owned(),
-                            fix: None,
-                        });
-                    }
-                    if link_text.ends_with(' ') {
-                        violations.push(Violation {
-                            line: line_number,
-                            column: Some(mat.start() + bracket_end),
-                            rule: self.name().to_owned(),
-                            message: "Spaces inside link text".to_owned(),
-                            fix: None,
-                        });
-                    }
+        for (event, range) in parser.parse_with_offsets() {
+            match event {
+                Event::Start(Tag::Link { .. }) => {
+                    in_link = true;
+                    text_span = None;
                 }
+                Event::End(TagEnd::Link) if in_link => {
+                    if let Some(span) = text_span.take() {
+                        violations.extend(self.spaces_in(content, &span, parser));
+                    }
+                    in_link = false;
+                }
+                // Every child event of the link is bounded by its `[`/`]`, so the
+                // first start and the last end bracket exactly the link text —
+                // including a nested image or code span at either edge.
+                _ if in_link => {
+                    text_span = Some(text_span.take().map_or(range.clone(), |span| {
+                        span.start.min(range.start)..span.end.max(range.end)
+                    }));
+                }
+                _ => {}
             }
         }
 
@@ -70,6 +98,7 @@ impl Rule for MD039 {
 mod tests {
     use super::*;
     use crate::lint::rules::rendered;
+    use indoc::indoc;
 
     #[test]
     fn test_correct_link() {
@@ -131,5 +160,86 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_code_block_not_flagged() {
+        let content = indoc! {"
+            Text
+
+            ```markdown
+            [ spaced ](url)
+            ```
+        "};
+        let parser = MarkdownParser::new(content);
+        let rule = MD039;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_code_span_not_flagged() {
+        let content = "Write it as `[ spaced ](url)` to show the mistake.";
+        let parser = MarkdownParser::new(content);
+        let rule = MD039;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_reference_link_flagged() {
+        let content = indoc! {"
+            See [ spaced ][ref] and [ collapsed ][].
+
+            [ref]: https://example.com
+            [ collapsed ]: https://example.com
+        "};
+        let parser = MarkdownParser::new(content);
+        let rule = MD039;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:6: MD039 Spaces inside link text",
+                "test.md:1:13: MD039 Spaces inside link text",
+                "test.md:1:26: MD039 Spaces inside link text",
+                "test.md:1:36: MD039 Spaces inside link text",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_destination_containing_parenthesis_flagged() {
+        let content = "See [ spaced ](https://example.com/a(b)c).";
+        let parser = MarkdownParser::new(content);
+        let rule = MD039;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:6: MD039 Spaces inside link text",
+                "test.md:1:13: MD039 Spaces inside link text",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_nested_image_edges_flagged() {
+        let content = "[ ![alt](image.png) ](https://example.com)";
+        let parser = MarkdownParser::new(content);
+        let rule = MD039;
+        let violations = rule.check(&parser, None);
+
+        assert_eq!(
+            rendered(&violations),
+            [
+                "test.md:1:2: MD039 Spaces inside link text",
+                "test.md:1:20: MD039 Spaces inside link text",
+            ]
+        );
     }
 }

--- a/src/lint/rules/md044.rs
+++ b/src/lint/rules/md044.rs
@@ -42,36 +42,44 @@ impl Rule for MD044 {
 
         let mut violations = Vec::new();
 
+        // Case-insensitive with word boundaries; compiled once per name rather
+        // than once per name per line.
+        let patterns: Vec<(&String, Regex)> = proper_names
+            .iter()
+            .filter_map(|name| {
+                Regex::new(&format!(r"(?i)\b{}\b", regex::escape(name)))
+                    .ok()
+                    .map(|re| (name, re))
+            })
+            .collect();
+
+        // The parser's code ranges cover code spans and both fenced and indented
+        // blocks — including the block *contents*, which a per-line "does this
+        // line look like code" test cannot see.
+        let code_ranges = parser.get_code_ranges();
+
         for (line_num, line) in parser.lines().iter().enumerate() {
             let line_number = line_num + 1;
 
-            // Skip code blocks if configured
-            if !code_blocks
-                && (line.starts_with("    ") || line.starts_with('\t') || line.contains("```"))
-            {
-                continue;
-            }
-
-            // Check each proper name
-            for name in &proper_names {
-                // Create case-insensitive regex with word boundaries
-                let pattern = format!(r"(?i)\b{}\b", regex::escape(name));
-                if let Ok(re) = Regex::new(&pattern) {
-                    for mat in re.find_iter(line) {
-                        let found = mat.as_str();
-                        // Check if capitalization matches
-                        if found != name {
-                            violations.push(Violation {
-                                line: line_number,
-                                column: Some(mat.start() + 1),
-                                rule: self.name().to_owned(),
-                                message: format!(
-                                    "Proper name '{found}' should be capitalized as '{name}'"
-                                ),
-                                fix: None,
-                            });
+            for (name, re) in &patterns {
+                for mat in re.find_iter(line) {
+                    let found = mat.as_str();
+                    if found == name.as_str() {
+                        continue;
+                    }
+                    if !code_blocks {
+                        let absolute = parser.line_offset_to_absolute(line_number, mat.start());
+                        if code_ranges.iter().any(|range| range.contains(&absolute)) {
+                            continue;
                         }
                     }
+                    violations.push(Violation {
+                        line: line_number,
+                        column: Some(mat.start() + 1),
+                        rule: self.name().to_owned(),
+                        message: format!("Proper name '{found}' should be capitalized as '{name}'"),
+                        fix: None,
+                    });
                 }
             }
         }
@@ -88,6 +96,7 @@ impl Rule for MD044 {
 mod tests {
     use super::*;
     use crate::lint::rules::rendered;
+    use indoc::indoc;
 
     #[test]
     fn test_no_config() {
@@ -143,5 +152,51 @@ mod tests {
 
         // Should only match whole word "JavaScript", not "JavaScriptCore"
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_code_blocks_false_skips_block_contents_and_spans() {
+        let content = indoc! {"
+            Run `javascript` first.
+
+            ```js
+            let javascript = 1;
+            ```
+
+            Then javascript again.
+        "};
+        let parser = MarkdownParser::new(content);
+        let rule = MD044;
+        let config = serde_json::json!({
+            "names": ["JavaScript"],
+            "code_blocks": false
+        });
+        let violations = rule.check(&parser, Some(&config));
+
+        // Only the prose occurrence on line 7 survives
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:7:6: MD044 Proper name 'javascript' should be capitalized as 'JavaScript'"]
+        );
+    }
+
+    #[test]
+    fn test_code_blocks_true_checks_code() {
+        let content = indoc! {"
+            ```js
+            let javascript = 1;
+            ```
+        "};
+        let parser = MarkdownParser::new(content);
+        let rule = MD044;
+        let config = serde_json::json!({
+            "names": ["JavaScript"]
+        });
+        let violations = rule.check(&parser, Some(&config));
+
+        assert_eq!(
+            rendered(&violations),
+            ["test.md:2:5: MD044 Proper name 'javascript' should be capitalized as 'JavaScript'"]
+        );
     }
 }

--- a/src/lint/rules/md049.rs
+++ b/src/lint/rules/md049.rs
@@ -44,6 +44,9 @@ impl Rule for MD049 {
 
             // Look for emphasis patterns: *text* or _text_ (not ** or __)
             let chars: Vec<char> = line.chars().collect();
+            // Byte offset of each char, since the code ranges are byte-based
+            // while the scan below (and the emitted columns) are char-based.
+            let char_offsets: Vec<usize> = line.char_indices().map(|(offset, _)| offset).collect();
             let mut i = 0;
 
             while i < chars.len() {
@@ -79,7 +82,10 @@ impl Rule for MD049 {
 
                                 if !close_is_strong && can_close {
                                     // Skip if this emphasis is inside code
-                                    if is_in_code(line_number, i) {
+                                    if is_in_code(
+                                        line_number,
+                                        char_offsets.get(i).copied().unwrap_or(line.len()),
+                                    ) {
                                         i = j; // Skip to after closing
                                         break;
                                     }
@@ -305,6 +311,18 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // Should not flag asterisks in code as emphasis markers
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_inline_code_after_multibyte_text() {
+        // The code ranges are byte offsets while the scan is char-based, so
+        // multibyte text ahead of the code span must not shift the lookup.
+        let content = "Café café café `_x_` here.";
+        let parser = MarkdownParser::new(content);
+        let rule = MD049;
+        let violations = rule.check(&parser, None);
+
         assert_eq!(violations.len(), 0);
     }
 }

--- a/src/lint/rules/md050.rs
+++ b/src/lint/rules/md050.rs
@@ -44,6 +44,9 @@ impl Rule for MD050 {
 
             // Look for strong patterns: **text** or __text__
             let chars: Vec<char> = line.chars().collect();
+            // Byte offset of each char, since the code ranges are byte-based
+            // while the scan below (and the emitted columns) are char-based.
+            let char_offsets: Vec<usize> = line.char_indices().map(|(offset, _)| offset).collect();
             let mut i = 0;
 
             while i + 1 < chars.len() {
@@ -67,7 +70,10 @@ impl Rule for MD050 {
                                 );
                                 if close_two == two_char {
                                     // Skip if this emphasis is inside code
-                                    if is_in_code(line_number, i) {
+                                    if is_in_code(
+                                        line_number,
+                                        char_offsets.get(i).copied().unwrap_or(line.len()),
+                                    ) {
                                         i = j; // Skip to after closing
                                         break;
                                     }
@@ -257,6 +263,18 @@ mod tests {
         let violations = rule.check(&parser, None);
 
         // Should not flag underscores inside inline code as strong markers
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_inline_code_after_multibyte_text() {
+        // The code ranges are byte offsets while the scan is char-based, so
+        // multibyte text ahead of the code span must not shift the lookup.
+        let content = "Café café café `__x__` here.";
+        let parser = MarkdownParser::new(content);
+        let rule = MD050;
+        let violations = rule.check(&parser, None);
+
         assert_eq!(violations.len(), 0);
     }
 }


### PR DESCRIPTION
Trying to get rid of regex matching and using the pulldown-cmark event stream instead. This hopefully fixes some of the remaining code block issues people have encountered.